### PR TITLE
fix jest config unit test directory and mock out Auth.currentCredentials calls in unit tests

### DIFF
--- a/__tests__/AmplibyMapLibreRequest.test.ts
+++ b/__tests__/AmplibyMapLibreRequest.test.ts
@@ -1,4 +1,16 @@
 import AmplifyMapLibreRequest from "../src/AmplifyMapLibreRequest";
+import { Auth } from "aws-amplify";
+
+Auth.currentCredentials = jest.fn().mockImplementation(() => {
+  return {
+    accessKeyId: "accessKeyId",
+    sessionToken: "sessionTokenId",
+    secretAccessKey: "secretAccessKey",
+    identityId: "identityId",
+    authenticated: true,
+    expiration: new Date(),
+  };
+});
 
 describe("AmplifyMapLibreRequest", () => {
   test("Constructor test", () => {
@@ -10,7 +22,7 @@ describe("AmplifyMapLibreRequest", () => {
       authenticated: true,
       expiration: new Date(),
     };
-    const amplifyRequest = new AmplifyMapLibreRequest(mockCreds);
+    const amplifyRequest = new AmplifyMapLibreRequest(mockCreds, "us-west-2");
     expect(amplifyRequest.credentials).toBe(mockCreds);
     expect(amplifyRequest.region).toBe("us-west-2");
     expect(typeof amplifyRequest.transformRequest).toBe("function");
@@ -25,7 +37,7 @@ describe("AmplifyMapLibreRequest", () => {
       authenticated: true,
       expiration: new Date(),
     };
-    const amplifyRequest = new AmplifyMapLibreRequest(mockCreds);
+    const amplifyRequest = new AmplifyMapLibreRequest(mockCreds, "us-west-2");
     expect(amplifyRequest.transformRequest("https://example.com", "any")).toBe(
       undefined
     );
@@ -40,7 +52,7 @@ describe("AmplifyMapLibreRequest", () => {
       authenticated: true,
       expiration: new Date(),
     };
-    const amplifyRequest = new AmplifyMapLibreRequest(mockCreds);
+    const amplifyRequest = new AmplifyMapLibreRequest(mockCreds, "us-west-2");
     const request = amplifyRequest.transformRequest("example.com", "Style");
     expect(request.url).toContain("maps.geo");
     expect(request.url).toContain("X-Amz-Signature");

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
+  testMatch: ["<rootDir>/__tests__/**/*.ts"],
 };


### PR DESCRIPTION
#### Description of changes
- `yarn test` was failing because it was looking for tests in wrong directory and was not updated to use the correct constructor
  - Fixed constructor
  - Added config to test directory
  - Added mock for Auth.currentCredentials so it wouldnt go crazy with retries
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added]

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
