### PR TITLE
feat: added geocoderApi for maplibre-gl-geocoder and amplify

### DIFF
--- a/__tests__/AmplifyMapLibreGeocoder.test.ts
+++ b/__tests__/AmplifyMapLibreGeocoder.test.ts
@@ -1,0 +1,113 @@
+import { AmplifyGeocoder } from "../src/AmplifyMapLibreGeocoder";
+import { Geo } from "@aws-amplify/geo";
+
+jest.mock("@aws-amplify/geo");
+
+describe("AmplifyGeocoder", () => {
+  beforeEach(() => {
+    (Geo.searchByText as jest.Mock).mockClear();
+    (Geo.searchByCoordinates as jest.Mock).mockClear();
+  });
+
+  test("forwardGeocode returns some values in the expected format", async () => {
+    const config = {
+      query: "a map query",
+    };
+    (Geo.searchByText as jest.Mock).mockReturnValueOnce([
+      {
+        addressNumber: "1800",
+        country: "USA",
+        geometry: {
+          point: [-123, 45],
+        },
+        label: "A fake place",
+        postalCode: "12345",
+        street: "1st Street",
+      },
+    ]);
+    const response = await AmplifyGeocoder.forwardGeocode(config);
+    expect(Geo.searchByText).toHaveBeenCalledTimes(1);
+    expect(response.features).toHaveLength(1);
+    expect(response.features[0].geometry).toBeDefined();
+  });
+
+  test("forwardGeocode returns empty feature array on empty response", async () => {
+    const config = {
+      query: "a map query",
+    };
+    (Geo.searchByText as jest.Mock).mockReturnValueOnce([]);
+    const response = await AmplifyGeocoder.forwardGeocode(config);
+    expect(Geo.searchByText).toHaveBeenCalledTimes(1);
+    expect(response.features).toHaveLength(0);
+  });
+
+  test("forwardGeocode returns empty feature array on undefined response", async () => {
+    const config = {
+      query: "a map query",
+    };
+    (Geo.searchByText as jest.Mock).mockReturnValueOnce(undefined);
+    const response = await AmplifyGeocoder.forwardGeocode(config);
+    expect(Geo.searchByText).toHaveBeenCalledTimes(1);
+    expect(response.features).toHaveLength(0);
+  });
+
+  test("forwardGeocode returns empty feature array on error", async () => {
+    const config = {
+      query: "a map query",
+    };
+    (Geo.searchByText as jest.Mock).mockRejectedValueOnce("an error");
+    const response = await AmplifyGeocoder.forwardGeocode(config);
+    expect(Geo.searchByText).toHaveBeenCalledTimes(1);
+    expect(response.features).toHaveLength(0);
+  });
+
+  test("reverseGeocode returns some values in the expected format", async () => {
+    const config = {
+      query: "-123, 45",
+    };
+    (Geo.searchByCoordinates as jest.Mock).mockReturnValueOnce({
+      addressNumber: "1800",
+      country: "USA",
+      geometry: {
+        point: [-123, 45],
+      },
+      label: "A fake place",
+      postalCode: "12345",
+      street: "1st Street",
+    });
+    const response = await AmplifyGeocoder.reverseGeocode(config);
+    expect(Geo.searchByCoordinates).toHaveBeenCalledTimes(1);
+    expect(response.features).toHaveLength(1);
+    expect(response.features[0].geometry).toBeDefined();
+  });
+
+  test("reverseGeocode returns empty feature array on empty response", async () => {
+    const config = {
+      query: "-123, 45",
+    };
+    (Geo.searchByCoordinates as jest.Mock).mockReturnValueOnce({});
+    const response = await AmplifyGeocoder.reverseGeocode(config);
+    expect(Geo.searchByCoordinates).toHaveBeenCalledTimes(1);
+    expect(response.features).toHaveLength(0);
+  });
+
+  test("reverseGeocode returns empty feature array on undefined response", async () => {
+    const config = {
+      query: "-123, 45",
+    };
+    (Geo.searchByCoordinates as jest.Mock).mockReturnValueOnce(undefined);
+    const response = await AmplifyGeocoder.reverseGeocode(config);
+    expect(Geo.searchByCoordinates).toHaveBeenCalledTimes(1);
+    expect(response.features).toHaveLength(0);
+  });
+
+  test("reverseGeocode returns empty feature array on error", async () => {
+    const config = {
+      query: "-123, 45",
+    };
+    (Geo.searchByCoordinates as jest.Mock).mockRejectedValueOnce("an error");
+    const response = await AmplifyGeocoder.reverseGeocode(config);
+    expect(Geo.searchByCoordinates).toHaveBeenCalledTimes(1);
+    expect(response.features).toHaveLength(0);
+  });
+});

--- a/src/AmplifyMapLibreGeocoder.ts
+++ b/src/AmplifyMapLibreGeocoder.ts
@@ -2,38 +2,56 @@ import { Geo } from "@aws-amplify/geo";
 
 export const AmplifyGeocoder = {
   forwardGeocode: async (config) => {
-    const data = await Geo.searchByText(config.query, {
-      biasPosition: config.proximity,
-      searchAreaConstraints: config.bbox,
-      countries: config.countires,
-      maxResults: config.limit,
-    });
-    const features = data.map((result) => {
-      const { geometry, ...otherResults } = result;
-      return {
-        type: "Feature",
-        geometry: { type: "Point", coordinates: geometry.point },
-        properties: { ...otherResults },
-        place_name: otherResults.label,
-        text: otherResults.label,
-        center: geometry.point,
-      };
-    });
+    const features = [];
+    try {
+      const data = await Geo.searchByText(config.query, {
+        biasPosition: config.proximity,
+        searchAreaConstraints: config.bbox,
+        countries: config.countires,
+        maxResults: config.limit,
+      });
+
+      if (data) {
+        data.forEach((result) => {
+          const { geometry, ...otherResults } = result;
+          features.push({
+            type: "Feature",
+            geometry: { type: "Point", coordinates: geometry.point },
+            properties: { ...otherResults },
+            place_name: otherResults.label,
+            text: otherResults.label,
+            center: geometry.point,
+          });
+        });
+      }
+    } catch (e) {
+      console.error(`Failed to forwardGeocode with error: ${e}`);
+    }
+
     return { features };
   },
   reverseGeocode: async (config) => {
-    const data = await Geo.searchByCoordinates(config.query, {
-      maxResults: config.limit,
-    });
-    const { geometry, ...otherResults } = data;
-    const feature = {
-      type: "Feature",
-      geometry: { type: "Point", coordinates: geometry.point },
-      properties: { ...otherResults },
-      place_name: otherResults.label,
-      text: otherResults.label,
-      center: geometry.point,
-    };
-    return { features: [feature] };
+    const features = [];
+    try {
+      const data = await Geo.searchByCoordinates(config.query, {
+        maxResults: config.limit,
+      });
+
+      if (data && data.geometry) {
+        const { geometry, ...otherResults } = data;
+        features.push({
+          type: "Feature",
+          geometry: { type: "Point", coordinates: geometry.point },
+          properties: { ...otherResults },
+          place_name: otherResults.label,
+          text: otherResults.label,
+          center: geometry.point,
+        });
+      }
+    } catch (e) {
+      console.error(`Failed to reverseGeocode with error: ${e}`);
+    }
+
+    return { features };
   },
 };

--- a/src/AmplifyMapLibreGeocoder.ts
+++ b/src/AmplifyMapLibreGeocoder.ts
@@ -1,0 +1,39 @@
+import { Geo } from "@aws-amplify/geo";
+
+export const AmplifyGeocoder = {
+  forwardGeocode: async (config) => {
+    const data = await Geo.searchByText(config.query, {
+      biasPosition: config.proximity,
+      searchAreaConstraints: config.bbox,
+      countries: config.countires,
+      maxResults: config.limit,
+    });
+    const features = data.map((result) => {
+      const { geometry, ...otherResults } = result;
+      return {
+        type: "Feature",
+        geometry: { type: "Point", coordinates: geometry.point },
+        properties: { ...otherResults },
+        place_name: otherResults.label,
+        text: otherResults.label,
+        center: geometry.point,
+      };
+    });
+    return { features };
+  },
+  reverseGeocode: async (config) => {
+    const data = await Geo.searchByCoordinates(config.query, {
+      maxResults: config.limit,
+    });
+    const { geometry, ...otherResults } = data;
+    const feature = {
+      type: "Feature",
+      geometry: { type: "Point", coordinates: geometry.point },
+      properties: { ...otherResults },
+      place_name: otherResults.label,
+      text: otherResults.label,
+      center: geometry.point,
+    };
+    return { features: [feature] };
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import AmplifyMapLibreRequest from "./AmplifyMapLibreRequest";
 import { drawPoints } from "./drawPoints";
+import { AmplifyGeocoder } from "./AmplifyMapLibreGeocoder";
 
-export { AmplifyMapLibreRequest, drawPoints };
+export { AmplifyMapLibreRequest, drawPoints, AmplifyGeocoder };


### PR DESCRIPTION
#### Description of changes
- Added an AmplifyGeocoder API that wraps `Geo.searchByText` and `Geo.searchByCoordinate` to be used with maplibre-gl-geocoder

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
