### PR TITLE
feat: added amplify-geocoder.css to set styles for maplibre-gl-geocoder to match amplify

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
     "/dist"
   ],
   "scripts": {
-    "build": "npm run clean && npm run compile && npm run bundle:umd && npm run bundle:umd:min",
+    "build": "npm run clean && npm run copy:files && npm run compile && npm run bundle:umd && npm run bundle:umd:min",
     "bundle:umd": "rollup dist/index.js --file dist/maplibre-gl-js-amplify.umd.js --format umd --name maplibreAmplify --config",
     "bundle:umd:min": "terser --ecma 6 --compress --mangle -o dist/maplibre-gl-js-amplify.umd.min.js -- dist/maplibre-gl-js-amplify.umd.js && gzip -9 -c dist/maplibre-gl-js-amplify.umd.min.js > dist/maplibre-gl-js-amplify.umd.min.js.gz",
     "clean": "rimraf dist",
     "compile": "npm run tsc",
+    "copy:files": "mkdir -p dist/ && cp src/amplify-geocoder.css dist/",
     "test": "jest",
     "tsc": "tsc"
   },

--- a/src/amplify-geocoder.css
+++ b/src/amplify-geocoder.css
@@ -1,0 +1,22 @@
+.maplibregl-ctrl-geocoder {
+  text-align: initial;
+}
+
+.mapboxgl-popup-tip {
+  display: none;
+}
+
+.maplibre-ctrl-geocoder--suggestion {
+  background: #fff;
+  border: 2px solid #0000001f;
+  color: #000;
+  border-radius: 4px;
+  padding: 20px;
+  word-wrap: break-word;
+  margin: -10px -10px -15px;
+  text-align: initial;
+}
+
+.maplibre-ctrl-geocoder--suggestion-title {
+  font-weight: bold;
+}


### PR DESCRIPTION


#### Description of changes
- Added `amplify-geocoder.css` which sets maplibre-gl-geocoder styles to match the amplify specific style
- Updated build steps for the css file
- This does not update marker styles just yet as that requires some changes to maplibre-gl-geocoder to allow for svg elements (which is what our markers use)

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
