### PR TITLE
chore: rename bundle to AmplifyMapLibre and move rollup settings to config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "build": "npm run clean && npm run copy:files && npm run compile && npm run bundle:umd && npm run bundle:umd:min",
-    "bundle:umd": "rollup dist/index.js --file dist/maplibre-gl-js-amplify.umd.js --format umd --name maplibreAmplify --config",
+    "bundle:umd": "rollup dist/index.js --config",
     "bundle:umd:min": "terser --ecma 6 --compress --mangle -o dist/maplibre-gl-js-amplify.umd.min.js -- dist/maplibre-gl-js-amplify.umd.js && gzip -9 -c dist/maplibre-gl-js-amplify.umd.min.js > dist/maplibre-gl-js-amplify.umd.min.js.gz",
     "clean": "rimraf dist",
     "compile": "npm run tsc",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,9 @@ import svg from "rollup-plugin-svg";
 export default {
   external: ["maplibre-gl", "@aws-amplify/core", "@aws-amplify/geo"],
   output: {
+    name: "AmplifyMapLibre",
+    format: "umd",
+    file: "dist/maplibre-gl-js-amplify.umd.js",
     globals: {
       "maplibre-gl": "maplibregl",
       "@aws-amplify/core": "aws_amplify_core",


### PR DESCRIPTION
#### Description of changes
- Moved bundle name to `AmplifyMapLibre`
- Moved various rollup cli settings to config file

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
