### PR TITLE
fix: add jest moduleNameMapper for non JS files

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,4 +6,8 @@ module.exports = {
     ".+\\.(svg|css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$":
       "jest-transform-stub",
   },
+  moduleNameMapper: {
+    "^.+.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$":
+      "jest-transform-stub",
+  },
 };


### PR DESCRIPTION
#### Description of changes
- Added jest config for `moduleNameMapper` so jest can properly parse css files

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added]

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
