### PR TITLE
feat: Updated drawPoints method to take NamedLocation data

### DIFF
--- a/API.md
+++ b/API.md
@@ -41,7 +41,10 @@ DrawPoints utility function for adding points to a map based on coordinate data 
 ### Parameters
 
 - `sourceName` **[String][8]** A user defined name used for determining the maplibre data source and the maplibre layers
-- `data` **([Array][13]\<Coordinate> | [Array][13]\<Feature>)** An array of coordinate data or GeoJSON Features used as the data source for maplibre
+- `data` **([Array][13]\<Coordinate> | [Array][13]\<Feature> | [Array][13]\<NamedLocation>)** An array of [coordinate](https://github.com/aws-amplify/maplibre-gl-js-amplify/blob/main/src/types.ts#L6) data, [GeoJSON Features][11], or [Named Locations](https://github.com/aws-amplify/maplibre-gl-js-amplify/blob/main/src/types.ts#L6) used as the data source for maplibre
+  - Coordinate data is an array of `Latitude` followed by `Longitude`
+  - GeoJSON Features should be an array of [Carmen GeoJSON Features][11]
+  - Named Locations is an array of objects containing the required field `coordinates` (same as the Coordinate data above) and the optional fields `title` and `address`. The `title` field will be bolded and on a separate line from the `address` field.
 - `map` **maplibre-gl-js-Map** A maplibre-gl-js [map][10] on which the points will be drawn
 - `options` **[Object][14]** An object containing options for changing the styles and features of the points rendered to the map, see the options for more details on available settings
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+- Updated `drawPoints` method to take new type `NamedLocation` data so that the title for each data point can be set
+
 ## 1.0.7
 
 ### Features / Improvements 🚀

--- a/src/drawClusterLayer.ts
+++ b/src/drawClusterLayer.ts
@@ -8,7 +8,7 @@ import {
   SymbolLayer,
 } from "maplibre-gl";
 import { ClusterOptions } from "./types";
-import { COLOR_WHITE, MARKER_COLOR, MAP_STYLES } from "./constants";
+import { COLOR_WHITE, MARKER_COLOR } from "./constants";
 import { isGeoJsonSource } from "./utils";
 import { FONT_DEFAULT_BY_STYLE } from "./constants";
 
@@ -32,7 +32,7 @@ export function drawClusterLayer(
     clusterCountLayout,
     fontColor = COLOR_WHITE,
   }: ClusterOptions,
-  mapStyle?: MAP_STYLES
+  mapStyle?: string
 ): { clusterLayerId: string; clusterSymbolLayerId: string } {
   const clusterLayerId = `${sourceName}-layer-clusters`;
   const clusterSymbolLayerId = `${sourceName}-layer-cluster-count`;

--- a/src/drawPoints.ts
+++ b/src/drawPoints.ts
@@ -1,7 +1,12 @@
 import { Feature } from "geojson";
 import { Map as maplibreMap } from "maplibre-gl";
 import { getFeaturesFromData } from "./utils";
-import { ClusterOptions, Coordinates, UnclusteredOptions } from "./types";
+import {
+  ClusterOptions,
+  Coordinates,
+  UnclusteredOptions,
+  NamedLocation,
+} from "./types";
 import { drawClusterLayer } from "./drawClusterLayer";
 import { drawUnclusteredLayer } from "./drawUnclusteredLayer";
 import { MAP_STYLES } from "./constants";
@@ -42,7 +47,7 @@ export interface DrawPointsOutput {
  */
 export function drawPoints(
   sourceName: string,
-  data: Coordinates[] | Feature[],
+  data: Coordinates[] | Feature[] | NamedLocation[],
   map: maplibreMap,
   {
     showCluster = true,

--- a/src/popupRender.ts
+++ b/src/popupRender.ts
@@ -23,19 +23,25 @@ export function getPopupRenderFunction(
       const placeName = selectedFeature.properties.place_name.split(",");
       title = placeName[0];
       address = placeName.splice(1, placeName.length).join(",");
+    } else if (
+      strHasLength(selectedFeature.properties.title) ||
+      strHasLength(selectedFeature.properties.address)
+    ) {
+      title = selectedFeature.properties.title;
+      address = selectedFeature.properties.address;
     } else {
       title = "Coordinates";
       address = (selectedFeature.geometry as Point).coordinates;
     }
 
-    return `
-      <div class="${unclusteredLayerId}-popup" style="background: ${background}; border: ${borderWidth}px solid ${borderColor}; color: ${fontColor}; border-radius: ${radius}px; padding: ${padding}px; word-wrap: break-word; margin: -10px -10px -15px;">
-        <div class="${unclusteredLayerId}-popup-title" style="font-weight: ${fontWeight};">
-          ${title}
-        </div>
-        <div class="${unclusteredLayerId}-popup-address">
-          ${address}
-        </div>
-      </div>`;
+    const titleHtml = `<div class="${unclusteredLayerId}-popup-title" style="font-weight: ${fontWeight};">${title}</div>`;
+    const addressHtml = `<div class="${unclusteredLayerId}-popup-address">${address}</div>`;
+
+    let popupHtml = `<div class="${unclusteredLayerId}-popup" style="background: ${background}; border: ${borderWidth}px solid ${borderColor}; color: ${fontColor}; border-radius: ${radius}px; padding: ${padding}px; word-wrap: break-word; margin: -10px -10px -15px;">`;
+    if (title) popupHtml += titleHtml;
+    if (address) popupHtml += addressHtml;
+    popupHtml += "</div>";
+
+    return popupHtml;
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,12 @@ export type Longitude = number;
 
 export type Coordinates = [Latitude, Longitude];
 
+export type NamedLocation = {
+  coordinates: Coordinates;
+  title?: string;
+  address?: string;
+};
+
 /**
  * @param {string} defaultColor Default: #5d8aff, color of a point
  * @param {string} defaultBorderColor Default: #fff, color of the points border


### PR DESCRIPTION
#### Description of changes
- Added `NamedLocation` type which contains `coordinates`, `title`, and `address`
- Updated `drawPoints` method to take `NamedLocation` array so that developers can set the `title` and `address` for each coordinate in the popup function
- Example:

```
drawPoints(
          "myPointData",
          [
            {
              coordinates: [-122.483696, 37.833818],
              title: "foobar",
              address: "foobar",
            },
          ],
          map,
          {
            showCluster: false,
            unclusteredOptions: {
              showMarkerPopup: true,
            },
          }
        );
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
- https://github.com/aws-amplify/maplibre-gl-js-amplify/issues/38

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Tested on local app

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added]
- [x] Relevant documentation is changed or added (and PR referenced)

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
