### PR TITLE
Allow popupRender to work properly

### DIFF
--- a/src/drawUnclusteredLayer.ts
+++ b/src/drawUnclusteredLayer.ts
@@ -15,7 +15,12 @@ export function drawUnclusteredLayer(
 ): { unclusteredLayerId: string } {
   const unclusteredLayerId = `${sourceName}-layer-unclustered-point`;
 
-  const popupRender = getPopupRenderFunction(unclusteredLayerId, options);
+  let popupRender;
+  if (options.popupRender) {
+    popupRender = options.popupRender;
+  } else {
+    popupRender = getPopupRenderFunction(unclusteredLayerId, options);
+  }
 
   addUnclusteredMarkerImages(map, options);
 

--- a/src/drawUnclusteredLayer.ts
+++ b/src/drawUnclusteredLayer.ts
@@ -15,12 +15,7 @@ export function drawUnclusteredLayer(
 ): { unclusteredLayerId: string } {
   const unclusteredLayerId = `${sourceName}-layer-unclustered-point`;
 
-  let popupRender;
-  if (options.popupRender) {
-    popupRender = options.popupRender;
-  } else {
-    popupRender = getPopupRenderFunction(unclusteredLayerId, options);
-  }
+  const popupRender = options.popupRender ? options.popupRender : getPopupRenderFunction(unclusteredLayerId, options);
 
   addUnclusteredMarkerImages(map, options);
 


### PR DESCRIPTION
This allows a user to use their own html popup rather than the default {title, address} format.

#### Description of changes

Unclustered Layer has an option to render your own popup, however does not implement this feature.

#### Description of how you validated changes

Tested on test enviorment, works fine.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
