### PR TITLE
Add CircleCI Configuration for Pulling Amplify Samples Integ Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,26 @@ jobs:
           framework: react
           category: geo
           sample_name: display-map
+      - integ_test_js:
+          test_name: "React Geo Marker Map"
+          framework: react
+          category: geo
+          sample_name: marker-map
+      - integ_test_js:
+          test_name: "React Geo Cluster Marker Map"
+          framework: react
+          category: geo
+          sample_name: cluster-marker-map
+      - integ_test_js:
+          test_name: "React Geo Search Map"
+          framework: react
+          category: geo
+          sample_name: search-map
+      - integ_test_js:
+          test_name: "React Geo Search Outside Map"
+          framework: react
+          category: geo
+          sample_name: search-outside-map
 
 releasable_branches: &releasable_branches
   branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,8 @@ jobs:
             echo $SSH_HOST_PUBLIC_KEY >> ~/.ssh/known_hosts
             git clone $AMPLIFY_JS_SAMPLES_STAGING_URL
             cd amplify-js-samples-staging
+            git fetch
+            git checkout geo-integ-update
             yarn
       - save_cache:
           key: maplibre-gl-js-amplify-{{ .Branch }}-{{ checksum "amplify-js-samples-staging/yarn.lock" }}
@@ -172,19 +174,16 @@ workflows:
             <<: *releasable_branches
       - integ_test_display:
           requires:
-            - build
             - integ_setup
           filters:
             <<: *releasable_branches
       - integ_test_marker:
           requires:
-            - build
             - integ_setup
           filters:
             <<: *releasable_branches
       - integ_test_search:
           requires:
-            - build
             - integ_setup
           filters:
             <<: *releasable_branches

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
           paths:
             - amplify-js-samples-staging
 
-  integ_test:
+  integ_test_display:
     executor: integ-test-executor
     working_directory: ~/
     steps:
@@ -115,6 +115,11 @@ jobs:
           framework: react
           category: geo
           sample_name: display-map
+
+  integ_test_marker:
+    executor: integ-test-executor
+    working_directory: ~/
+    steps:
       - integ_test_js:
           test_name: "React Geo Marker Map"
           framework: react
@@ -125,6 +130,11 @@ jobs:
           framework: react
           category: geo
           sample_name: cluster-marker-map
+
+  integ_test_search:
+    executor: integ-test-executor
+    working_directory: ~/
+    steps:
       - integ_test_js:
           test_name: "React Geo Search Map"
           framework: react
@@ -154,7 +164,19 @@ workflows:
             - build
           filters:
             <<: *releasable_branches
-      - integ_test:
+      - integ_test_display:
+          requires:
+            - build
+            - integ_setup
+          filters:
+            <<: *releasable_branches
+      - integ_test_marker:
+          requires:
+            - build
+            - integ_setup
+          filters:
+            <<: *releasable_branches
+      - integ_test_search:
           requires:
             - build
             - integ_setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,8 +83,8 @@ workflows:
   integration_test:
     jobs:
       - build
-      - unit_test
-        requires:
+      - unit_test:
+          requires:
             - build
       - integ_setup:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,9 +94,7 @@ jobs:
 releasable_branches: &releasable_branches
   branches:
     only:
-      - release
       - main
-      - integ-test
 
 workflows:
   integration_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,11 @@ executors:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_ACCESS_TOKEN
     resource_class: large
+    working_directory: ~/maplibre-gl-js-amplify
 
 jobs:
   build:
     executor: build-executor
-    working_directory: ~/
     steps:
       - checkout
       - run: yarn
@@ -29,7 +29,6 @@ jobs:
 
   unit_test:
     executor: build-executor
-    working_directory: ~/maplibre-gl-js-amplify
     steps:
       - attach_workspace:
           at: /root

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,11 +84,16 @@ workflows:
     jobs:
       - build
       - unit_test
+        requires:
+            - build
       - integ_setup:
+          requires:
+            - build
           filters:
             <<: *releasable_branches
       - integ_test:
           requires:
+            - build
             - integ_setup
           filters:
             <<: *releasable_branches

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,92 @@
 version: 2.1
-jobs:
-  build:
+
+executors:
+  build-executor:
     docker:
       - image: cypress/base:12
         auth:
-          username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD # context / project UI env-var reference
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_ACCESS_TOKEN
+    resource_class: large
+
+jobs:
+  build:
+    executor: build-executor
     working_directory: ~/maplibre-gl-js-amplify
     steps:
       - checkout # check out the code in the project directory
       - run: yarn
       - run: yarn build
+      - run: yarn link
+      - persist_to_workspace:
+          root: /root
+          paths:
+            - maplibre-gl-js-amplify
+
+  unit_test:
+    executor: build-executor
+    working_directory: ~/maplibre-gl-js-amplify
+    steps:
+      - attach_workspace:
+          at: /root
       - run: yarn test
+  
+  integ_setup:
+    executor: build-executor
+    working_directory: ~/
+    steps:
+      - run:
+          name: 'Clone Amplify JS Samples repo, install cypress, install react samples authenticator and link amplify packages'
+          command: |
+            mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
+            echo $SSH_HOST_PUBLIC_KEY >> ~/.ssh/known_hosts
+            git clone $AMPLIFY_JS_SAMPLES_STAGING_URL
+            cd amplify-js-samples-staging
+            yarn
+      - persist_to_workspace:
+          root: /root
+          paths:
+            - amplify-js-samples-staging
+
+  integ_test:
+    executor: build-executor
+    working_directory: ~/
+    steps:
+      - run:
+          name: 'Change directory into build and run link'
+          command: |
+            cd ~/maplibre-gl-js-amplify/
+            yarn link
+      - run:
+          name: 'Link packages into samples staging root'
+          command: |
+            cd ~/amplify-js-samples-staging
+            yarn link maplibre-gl-js-amplify
+      - run:
+          name: 'Run cypress test << parameters.spec >>'
+          command: |
+            cd ~/amplify-js-samples-staging
+            yarn ci:test react geo display-map
+      - store_artifacts:
+          path: ~/amplify-js-samples-staging/cypress/videos
+      - store_artifacts:
+          path: ~/amplify-js-samples-staging/cypress/screenshots
+
+releasable_branches: &releasable_branches
+  branches:
+    only:
+      - release
+      - main
+      - integ-test
+
+workflows:
+  integration_test:
+    jobs:
+      - build
+      - unit_test
+      - integ_setup
+          filters:
+            <<: *releasable_branches
+      - integ_test
+          filters:
+            <<: *releasable_branches

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,13 +30,13 @@ jobs:
       - attach_workspace:
           at: /root
       - run: yarn test
-  
+
   integ_setup:
     executor: build-executor
     working_directory: ~/
     steps:
       - run:
-          name: 'Clone Amplify JS Samples repo, install cypress, install react samples authenticator and link amplify packages'
+          name: "Clone Amplify JS Samples repo, install cypress, install react samples authenticator and link amplify packages"
           command: |
             mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
             echo $SSH_HOST_PUBLIC_KEY >> ~/.ssh/known_hosts
@@ -53,17 +53,17 @@ jobs:
     working_directory: ~/
     steps:
       - run:
-          name: 'Change directory into build and run link'
+          name: "Change directory into build and run link"
           command: |
             cd ~/maplibre-gl-js-amplify/
             yarn link
       - run:
-          name: 'Link packages into samples staging root'
+          name: "Link packages into samples staging root"
           command: |
             cd ~/amplify-js-samples-staging
             yarn link maplibre-gl-js-amplify
       - run:
-          name: 'Run cypress test << parameters.spec >>'
+          name: "Run cypress test << parameters.spec >>"
           command: |
             cd ~/amplify-js-samples-staging
             yarn ci:test react geo display-map
@@ -84,9 +84,11 @@ workflows:
     jobs:
       - build
       - unit_test
-      - integ_setup
+      - integ_setup:
           filters:
             <<: *releasable_branches
-      - integ_test
+      - integ_test:
+          requires:
+            - integ_setup
           filters:
             <<: *releasable_branches

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,8 @@ jobs:
     executor: build-executor
     working_directory: ~/
     steps:
+      - attach_workspace:
+          at: /root
       - run:
           name: "Change directory into build and run link"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
             cd ~/amplify-js-samples-staging
             yarn link maplibre-gl-js-amplify
       - run:
-          name: "Run cypress test << parameters.spec >>"
+          name: "Run cypress test"
           command: |
             cd ~/amplify-js-samples-staging
             yarn ci:test react geo display-map

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,23 @@ executors:
     resource_class: large
 
 commands:
+  prepare_test_env:
+    steps:
+      - attach_workspace:
+          at: /root
+      - restore_cache:
+          key: maplibre-gl-js-amplify-{{ .Branch }}-{{ checksum "amplify-js-samples-staging/yarn.lock" }}
+      - run:
+          name: "Change directory into build and run link"
+          command: |
+            cd ~/maplibre-gl-js-amplify/
+            yarn link
+      - run:
+          name: "Link packages into samples staging root"
+          command: |
+            cd ~/amplify-js-samples-staging
+            yarn link maplibre-gl-js-amplify
+
   integ_test_js:
     parameters:
       test_name:
@@ -37,20 +54,6 @@ commands:
         type: string
         default: ""
     steps:
-      - attach_workspace:
-          at: /root
-      - restore_cache:
-          key: maplibre-gl-js-amplify-{{ .Branch }}-{{ checksum "amplify-js-samples-staging/yarn.lock" }}
-      - run:
-          name: "Change directory into build and run link"
-          command: |
-            cd ~/maplibre-gl-js-amplify/
-            yarn link
-      - run:
-          name: "Link packages into samples staging root"
-          command: |
-            cd ~/amplify-js-samples-staging
-            yarn link maplibre-gl-js-amplify
       - run:
           name: "Run cypress test << parameters.test_name >>"
           command: |
@@ -110,6 +113,7 @@ jobs:
     executor: integ-test-executor
     working_directory: ~/
     steps:
+      - prepare_test_env
       - integ_test_js:
           test_name: "React Geo Display Map"
           framework: react
@@ -120,6 +124,7 @@ jobs:
     executor: integ-test-executor
     working_directory: ~/
     steps:
+      - prepare_test_env
       - integ_test_js:
           test_name: "React Geo Marker Map"
           framework: react
@@ -135,6 +140,7 @@ jobs:
     executor: integ-test-executor
     working_directory: ~/
     steps:
+      - prepare_test_env
       - integ_test_js:
           test_name: "React Geo Search Map"
           framework: react

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,12 +12,16 @@ executors:
 jobs:
   build:
     executor: build-executor
-    working_directory: ~/maplibre-gl-js-amplify
+    working_directory: ~/
     steps:
-      - checkout # check out the code in the project directory
+      - checkout
       - run: yarn
       - run: yarn build
       - run: yarn link
+      - save_cache:
+          key: amplify-maplibre-ssh-deps-{{ .Branch }}
+          paths:
+            - ~/.ssh
       - persist_to_workspace:
           root: /root
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,49 @@ executors:
           password: $DOCKERHUB_ACCESS_TOKEN
     resource_class: large
 
+commands:
+  integ_test_js:
+    parameters:
+      test_name:
+        type: string
+      framework:
+        type: string
+      category:
+        type: string
+      sample_name:
+        type: string
+      spec:
+        # optional - the script will use sample_name by default
+        type: string
+        default: ""
+      browser:
+        type: string
+        default: ""
+    steps:
+      - attach_workspace:
+          at: /root
+      - restore_cache:
+          key: maplibre-gl-js-amplify-{{ .Branch }}-{{ checksum "amplify-js-samples-staging/yarn.lock" }}
+      - run:
+          name: "Change directory into build and run link"
+          command: |
+            cd ~/maplibre-gl-js-amplify/
+            yarn link
+      - run:
+          name: "Link packages into samples staging root"
+          command: |
+            cd ~/amplify-js-samples-staging
+            yarn link maplibre-gl-js-amplify
+      - run:
+          name: "Run cypress test << parameters.test_name >>"
+          command: |
+            cd ~/amplify-js-samples-staging
+            yarn ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >> << parameters.browser >>
+      - store_artifacts:
+          path: ~/amplify-js-samples-staging/cypress/videos
+      - store_artifacts:
+          path: ~/amplify-js-samples-staging/cypress/screenshots
+
 jobs:
   build:
     executor: build-executor
@@ -67,34 +110,17 @@ jobs:
     executor: integ-test-executor
     working_directory: ~/
     steps:
-      - attach_workspace:
-          at: /root
-      - restore_cache:
-          key: maplibre-gl-js-amplify-{{ .Branch }}-{{ checksum "amplify-js-samples-staging/yarn.lock" }}
-      - run:
-          name: "Change directory into build and run link"
-          command: |
-            cd ~/maplibre-gl-js-amplify/
-            yarn link
-      - run:
-          name: "Link packages into samples staging root"
-          command: |
-            cd ~/amplify-js-samples-staging
-            yarn link maplibre-gl-js-amplify
-      - run:
-          name: "Run cypress test"
-          command: |
-            cd ~/amplify-js-samples-staging
-            yarn ci:test react geo display-map
-      - store_artifacts:
-          path: ~/amplify-js-samples-staging/cypress/videos
-      - store_artifacts:
-          path: ~/amplify-js-samples-staging/cypress/screenshots
+      - integ_test_js:
+          test_name: "React Geo Display Map"
+          framework: react
+          category: geo
+          sample_name: display-map
 
 releasable_branches: &releasable_branches
   branches:
     only:
       - main
+      - integ-test
 
 workflows:
   integration_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,14 @@ executors:
     resource_class: large
     working_directory: ~/maplibre-gl-js-amplify
 
+  integ-test-executor:
+    docker:
+      - image: cypress/included:5.2.0
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_ACCESS_TOKEN
+    resource_class: large
+
 jobs:
   build:
     executor: build-executor
@@ -46,17 +54,23 @@ jobs:
             git clone $AMPLIFY_JS_SAMPLES_STAGING_URL
             cd amplify-js-samples-staging
             yarn
+      - save_cache:
+          key: maplibre-gl-js-amplify-{{ .Branch }}-{{ checksum "amplify-js-samples-staging/yarn.lock" }}
+          paths:
+            - ~/.cache ## cache both yarn and Cypress
       - persist_to_workspace:
           root: /root
           paths:
             - amplify-js-samples-staging
 
   integ_test:
-    executor: build-executor
+    executor: integ-test-executor
     working_directory: ~/
     steps:
       - attach_workspace:
           at: /root
+      - restore_cache:
+          key: maplibre-gl-js-amplify-{{ .Branch }}-{{ checksum "amplify-js-samples-staging/yarn.lock" }}
       - run:
           name: "Change directory into build and run link"
           command: |


### PR DESCRIPTION
#### Description of changes
- Pulls amplify-js-samples-staging package and runs e2e tests contained there
- Links maplibre-gl-js-amplify to amplify-js-samples-staging

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added]

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
