### PR TITLE
Fix: Deselecting Point by Clicking outside map

### DIFF
--- a/src/drawUnclusteredLayer.ts
+++ b/src/drawUnclusteredLayer.ts
@@ -16,6 +16,17 @@ export function drawUnclusteredLayer(
   const unclusteredLayerId = `${sourceName}-layer-unclustered-point`;
   let selectedId = null;
 
+  function deselectPoint() {
+    if (selectedId !== null) {
+      map.setLayoutProperty(
+        unclusteredLayerId,
+        "icon-image",
+        "inactive-marker"
+      );
+      selectedId = null;
+    }
+  }
+
   const popupRender = options.popupRender
     ? options.popupRender
     : getPopupRenderFunction(unclusteredLayerId, options);
@@ -47,14 +58,7 @@ export function drawUnclusteredLayer(
   }
 
   map.on("click", function () {
-    if (selectedId !== null) {
-      map.setLayoutProperty(
-        unclusteredLayerId,
-        "icon-image",
-        "inactive-marker"
-      );
-      selectedId = null;
-    }
+    deselectPoint();
   });
 
   /*
@@ -79,11 +83,15 @@ export function drawUnclusteredLayer(
       const coordinates = (selectedFeature.geometry as Point).coordinates;
 
       if (isCoordinates(coordinates)) {
-        new Popup()
+        const popup = new Popup()
           .setLngLat(coordinates as Coordinates)
           .setHTML(popupRender(selectedFeature))
           .setOffset(15)
           .addTo(map);
+
+        popup.on("close", function () {
+          if (selectedId === selectedFeature.id) deselectPoint();
+        });
       }
     }
   });

--- a/src/drawUnclusteredLayer.ts
+++ b/src/drawUnclusteredLayer.ts
@@ -14,8 +14,11 @@ export function drawUnclusteredLayer(
   { showMarkerPopup = false, ...options }: UnclusteredOptions
 ): { unclusteredLayerId: string } {
   const unclusteredLayerId = `${sourceName}-layer-unclustered-point`;
+  let selectedId = null;
 
-  const popupRender = options.popupRender ? options.popupRender : getPopupRenderFunction(unclusteredLayerId, options);
+  const popupRender = options.popupRender
+    ? options.popupRender
+    : getPopupRenderFunction(unclusteredLayerId, options);
 
   addUnclusteredMarkerImages(map, options);
 
@@ -43,16 +46,29 @@ export function drawUnclusteredLayer(
     }
   }
 
+  map.on("click", function () {
+    if (selectedId !== null) {
+      map.setLayoutProperty(
+        unclusteredLayerId,
+        "icon-image",
+        "inactive-marker"
+      );
+      selectedId = null;
+    }
+  });
+
   /*
    * Set active state on markers when clicked
    */
   map.on("click", unclusteredLayerId, function (e) {
     if (typeof options.onClick === "function") options.onClick(e);
 
+    selectedId = e.features[0].id;
+
     map.setLayoutProperty(unclusteredLayerId, "icon-image", [
       "match",
       ["id"],
-      e.features[0].id, // check if the clicked id matches
+      selectedId, // check if the clicked id matches
       "active-marker", //image when id is the clicked feature id
       "inactive-marker", // default
     ]);


### PR DESCRIPTION
#### Description of changes
- When clicking a point then clicking anywhere away from the point the point was remaining in the highlighted state
- Fixed so when clicking on the map, closing a popup, or any other point it will deselect the original point

![Untitled](https://user-images.githubusercontent.com/68032955/135132986-eba2adf2-f50a-4561-936a-0a1c8ae5dc2b.gif)
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
