### PR TITLE
feat: add circle mode, refact mapbox draw into own file

### DIFF
--- a/__tests__/AmplifyGeofenceControl.test.ts
+++ b/__tests__/AmplifyGeofenceControl.test.ts
@@ -1,17 +1,11 @@
-import MapboxDraw from "@mapbox/mapbox-gl-draw";
 import { Map as maplibreMap } from "maplibre-gl";
 import { AmplifyGeofenceControl } from "../src/AmplifyGeofenceControl";
 import { getGeofenceFeatureFromPolygon } from "../src/geofenceUtils";
 import { AmplifyGeofenceControlUI } from "../src/AmplifyGeofenceControl/ui";
+import { AmplifyMapboxDraw } from "../src/AmplifyGeofenceControl/AmplifyMapboxDraw";
 
 const drawGet = jest.fn();
-jest.mock("@mapbox/mapbox-gl-draw", () => {
-  return jest.fn().mockImplementation(() => {
-    return {
-      get: drawGet,
-    };
-  });
-});
+jest.mock("../src/AmplifyGeofenceControl/AmplifyMapboxDraw");
 
 jest.mock("../src/AmplifyGeofenceControl/ui");
 jest.mock("maplibre-gl");
@@ -38,17 +32,22 @@ describe("AmplifyGeofenceControl", () => {
       };
     });
 
-    drawGet.mockImplementation(() =>
-      getGeofenceFeatureFromPolygon([
-        [
-          [-124.0488709112, 35.9978649131],
-          [-119.5127318998, 35.9978649131],
-          [-119.5127318998, 38.315786399],
-          [-124.0488709112, 38.315786399],
-          [-124.0488709112, 35.9978649131],
-        ],
-      ])
-    );
+    (AmplifyMapboxDraw as jest.Mock).mockImplementation(() => {
+      return {
+        get: () =>
+          getGeofenceFeatureFromPolygon([
+            [
+              [-124.0488709112, 35.9978649131],
+              [-119.5127318998, 35.9978649131],
+              [-119.5127318998, 38.315786399],
+              [-124.0488709112, 38.315786399],
+              [-124.0488709112, 35.9978649131],
+            ],
+          ]),
+        disable: jest.fn(),
+        enable: jest.fn(),
+      };
+    });
   });
 
   test("Constructor test", () => {
@@ -67,6 +66,7 @@ describe("AmplifyGeofenceControl", () => {
       control,
       {} as unknown as HTMLElement
     );
+    control._amplifyDraw = new AmplifyMapboxDraw(control._map, control._ui);
     control._drawGeofencesOutput = mockDrawGeofencesOutput;
 
     control._editingGeofenceId = "foobar";

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@mapbox/mapbox-gl-draw": "^1.3.0",
     "@maplibre/maplibre-gl-geocoder": "^1.1.0",
     "@turf/along": "^6.5.0",
+    "@turf/circle": "^6.5.0",
     "@turf/distance": "^6.5.0",
     "@turf/helpers": "^6.5.0",
     "mapbox-gl-draw-circle": "^1.1.2"

--- a/src/AmplifyGeofenceControl/AmplifyMapboxDraw.ts
+++ b/src/AmplifyGeofenceControl/AmplifyMapboxDraw.ts
@@ -86,6 +86,10 @@ export class AmplifyMapboxDraw {
     this._ui.createGeofenceCreateContainer();
   }
 
+  /**
+   * Draws a polygonal geofence around the center of the current map view. The polygon defaults to 3/4 the size of the current map bounds
+   * @param id the geofence geojson id
+   */
   drawPolygonGeofence(id: string): void {
     const mapBounds = this._map.getBounds();
     const polygon = getPolygonFromBounds(mapBounds);
@@ -96,6 +100,11 @@ export class AmplifyMapboxDraw {
     this.add(data);
   }
 
+  /**
+   * Draws a cicular geofence around the center of the current map view
+   * @param id the geofence geojson id
+   * @param radius optional parameter for setting the radius of the cicular geofence, default to 1/8th of the current map bounds length
+   */
   drawCircularGeofence(id: string, radius?: number): void {
     const mapBounds = this._map.getBounds();
     const circleFeature = getCircleFeatureFromCoords(

--- a/src/AmplifyGeofenceControl/AmplifyMapboxDraw.ts
+++ b/src/AmplifyGeofenceControl/AmplifyMapboxDraw.ts
@@ -1,0 +1,111 @@
+import MapboxDraw from "@mapbox/mapbox-gl-draw";
+import { IControl, Map } from "maplibre-gl";
+import {
+  CircleMode,
+  SimpleSelectMode,
+  DirectMode,
+} from "mapbox-gl-draw-circle";
+import { Coordinates } from "../types";
+import { Feature, Geometry } from "geojson";
+import {
+  getPolygonFromBounds,
+  getGeofenceFeatureFromPolygon,
+  getCircleFeatureFromCoords,
+} from "../geofenceUtils";
+
+export class AmplifyMapboxDraw {
+  _map: Map;
+  _ui;
+  _mapBoxDraw: MapboxDraw = new MapboxDraw({
+    displayControlsDefault: false,
+    defaultMode: "simple_select",
+    userProperties: true,
+    controls: {
+      trash: false,
+    },
+    modes: {
+      ...MapboxDraw.modes,
+      draw_circle: CircleMode,
+      direct_select: DirectMode,
+      simple_select: SimpleSelectMode,
+    },
+  });
+
+  constructor(map: Map, ui) {
+    this._map = map;
+    this._ui = ui;
+    this.enable = this.enable.bind(this);
+    this.disable = this.disable.bind(this);
+
+    this.drawPolygonGeofence = this.drawPolygonGeofence.bind(this);
+  }
+
+  get(id: string): Feature<
+    Geometry,
+    {
+      [name: string]: any;
+    }
+  > {
+    return this._mapBoxDraw.get(id);
+  }
+
+  add(
+    data: Feature<
+      Geometry,
+      {
+        [name: string]: any;
+      }
+    >
+  ): void {
+    this.enable();
+    this._mapBoxDraw.add(data);
+    this._mapBoxDraw.changeMode("direct_select" as any, {
+      featureId: data.id as string,
+    });
+  }
+
+  delete(id: string): void {
+    this._mapBoxDraw.delete(id);
+  }
+
+  disable(): void {
+    if (this._map.hasControl(this._mapBoxDraw as unknown as IControl)) {
+      this._map.removeControl(this._mapBoxDraw as unknown as IControl);
+    }
+    this._ui.removeGeofenceCreateContainer();
+  }
+
+  enable(): void {
+    if (this._map.hasControl(this._mapBoxDraw as unknown as IControl)) {
+      return;
+    }
+    this._map.addControl(
+      this._mapBoxDraw as unknown as IControl,
+      "bottom-right"
+    );
+    this._ui.createGeofenceCreateContainer();
+  }
+
+  drawPolygonGeofence(id: string): void {
+    const mapBounds = this._map.getBounds();
+    const polygon = getPolygonFromBounds(mapBounds);
+    const data: Feature = {
+      id,
+      ...getGeofenceFeatureFromPolygon(polygon),
+    };
+    this.add(data);
+  }
+
+  drawCircularGeofence(id: string, radius?: number): void {
+    const mapBounds = this._map.getBounds();
+    const circleFeature = getCircleFeatureFromCoords(
+      this._map.getCenter().toArray() as Coordinates,
+      { bounds: mapBounds, radius }
+    );
+    const data: Feature = {
+      id,
+      ...circleFeature,
+    };
+    this.add(data);
+  }
+}

--- a/src/AmplifyGeofenceControl/ui.ts
+++ b/src/AmplifyGeofenceControl/ui.ts
@@ -28,6 +28,7 @@ export function AmplifyGeofenceControlUI(
   let _addGeofencebutton: HTMLButtonElement;
   let _checkboxAll: HTMLInputElement;
   let _geofenceList: HTMLElement;
+  let _createContainer: HTMLElement;
 
   function registerControlPosition(map, positionName): void {
     if (map._controlPositions[positionName]) {
@@ -55,7 +56,7 @@ export function AmplifyGeofenceControlUI(
   }
 
   function createGeofenceCreateContainer(): void {
-    const createContainer = createElement(
+    _createContainer = createElement(
       "div",
       "amplify-ctrl-create-prompt",
       geofenceControlContainer
@@ -64,7 +65,7 @@ export function AmplifyGeofenceControlUI(
     const geofenceCreateInput = createElement(
       "input",
       "amplify-ctrl-create-input",
-      createContainer
+      _createContainer
     );
     geofenceCreateInput.addEventListener(
       "keydown",
@@ -74,7 +75,7 @@ export function AmplifyGeofenceControlUI(
     const saveGeofenceButton = createElement(
       "button",
       "amplify-ctrl-create-save-button",
-      createContainer
+      _createContainer
     );
     saveGeofenceButton.addEventListener("click", geofenceControl.saveGeofence);
     saveGeofenceButton.title = "Save Geofence";
@@ -83,12 +84,10 @@ export function AmplifyGeofenceControlUI(
     const circleModeButton = createElement(
       "button",
       "amplify-ctrl-create-circle-button",
-      createContainer
+      _createContainer
     );
     circleModeButton.addEventListener("click", () =>
-      geofenceControl.changeMode("draw_circle", {
-        initialRadiusInKm: 50.0,
-      })
+      geofenceControl.changeMode("draw_circle")
     );
     circleModeButton.title = "Circle Mode";
     circleModeButton.innerHTML = "Circle Mode";
@@ -96,13 +95,17 @@ export function AmplifyGeofenceControlUI(
     const polygonModeButton = createElement(
       "button",
       "amplify-ctrl-create-polygon-button",
-      createContainer
+      _createContainer
     );
     polygonModeButton.addEventListener("click", () =>
       geofenceControl.changeMode("draw_polygon")
     );
     polygonModeButton.title = "Polygon Mode";
     polygonModeButton.innerHTML = "Polygon Mode";
+  }
+
+  function removeAddGeofenceContainer(): void {
+    removeElement(_addGeofenceContainer);
   }
 
   function createGeofenceListContainer() {
@@ -150,8 +153,8 @@ export function AmplifyGeofenceControlUI(
     );
   }
 
-  function removeAddGeofenceContainer(): void {
-    removeElement(_addGeofenceContainer);
+  function removeGeofenceCreateContainer(): void {
+    removeElement(_createContainer);
   }
 
   function createAddGeofenceContainer(): void {
@@ -374,5 +377,6 @@ export function AmplifyGeofenceControlUI(
     enableGeofenceList,
     disableGeofenceList,
     getCheckboxAllValue,
+    removeGeofenceCreateContainer,
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2586,7 +2586,7 @@
     "@turf/helpers" "^6.5.0"
     "@turf/invariant" "^6.5.0"
 
-"@turf/circle@^6.0.1":
+"@turf/circle@^6.0.1", "@turf/circle@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/circle/-/circle-6.5.0.tgz#dc017d8c0131d1d212b7c06f76510c22bbeb093c"
   integrity sha512-oU1+Kq9DgRnoSbWFHKnnUdTmtcRUMmHoV9DjTXu9vOLNV5OWtAAh1VZ+mzsioGGzoDNT/V5igbFOkMfBQc0B6A==


### PR DESCRIPTION
#### Description of changes
- Refactored mapbox draw to it's own class wrapper called AmplifyMapboxDraw
- Updated circle_mode button to draw a circle with radius 1/8 the diagonal length of the screen

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
