### PR TITLE
Update class names to be prefixed with geofence

### DIFF
--- a/src/AmplifyGeofenceControl/index.ts
+++ b/src/AmplifyGeofenceControl/index.ts
@@ -86,7 +86,7 @@ export class AmplifyGeofenceControl {
 
     this.reorderMapLibreClassNames();
 
-    this._container = createElement("div", "amplify-ctrl maplibregl-ctrl");
+    this._container = createElement("div", "geofence-ctrl maplibregl-ctrl");
 
     this._ui = AmplifyGeofenceControlUI(this, this._container);
     this._amplifyDraw = new AmplifyMapDraw(map, this._ui);
@@ -282,7 +282,7 @@ export class AmplifyGeofenceControl {
     this._displayedGeofences.push(...Object.values(this._loadedGeofences));
     this._updateDisplayedGeofences();
     const checkboxes = document.getElementsByClassName(
-      "amplify-ctrl-list-item-checkbox"
+      "geofence-ctrl-list-item-checkbox"
     ) as HTMLCollectionOf<HTMLInputElement>;
     Array.from(checkboxes).forEach(
       (checkbox) => (checkbox.checked = this._ui.getCheckboxAllValue())
@@ -301,7 +301,7 @@ export class AmplifyGeofenceControl {
     this._displayedGeofences = [];
     this._updateDisplayedGeofences();
     const checkboxes = document.getElementsByClassName(
-      "amplify-ctrl-list-item-checkbox"
+      "geofence-ctrl-list-item-checkbox"
     ) as HTMLCollectionOf<HTMLInputElement>;
     Array.from(checkboxes).forEach(
       (checkbox) => (checkbox.checked = this._ui.getCheckboxAllValue())

--- a/src/AmplifyGeofenceControl/ui.ts
+++ b/src/AmplifyGeofenceControl/ui.ts
@@ -44,13 +44,13 @@ export function AmplifyGeofenceControlUI(
   function createGeofenceCreateContainer(isCircle?: boolean): void {
     const container = createElement(
       "div",
-      "amplify-ctrl-create-prompt-container",
+      "geofence-ctrl-create-prompt-container",
       geofenceControlContainer
     );
 
     _createContainer = createElement(
       "div",
-      "amplify-ctrl-create-prompt",
+      "geofence-ctrl-create-prompt",
       container
     );
 
@@ -58,21 +58,21 @@ export function AmplifyGeofenceControlUI(
       /* Create buttons to switch between different modes */
       const buttonContainer = createElement(
         "div",
-        "amplify-ctrl-create-prompt-buttons",
+        "geofence-ctrl-create-prompt-buttons",
         _createContainer
       );
 
       const circleModeButton = createElement(
         "div",
-        "amplify-ctrl-create-prompt-button-circle amplify-ctrl-create-prompt-button",
+        "geofence-ctrl-create-prompt-button-circle geofence-ctrl-create-prompt-button",
         buttonContainer
       );
       circleModeButton.addEventListener("click", () => {
         geofenceControl.changeMode("draw_circle");
         // Change button selected style
-        circleModeButton.classList.add("amplify-ctrl-create-prompt-selected");
+        circleModeButton.classList.add("geofence-ctrl-create-prompt-selected");
         polygonModeButton.classList.remove(
-          "amplify-ctrl-create-prompt-selected"
+          "geofence-ctrl-create-prompt-selected"
         );
 
         // Switch info box mode
@@ -87,15 +87,15 @@ export function AmplifyGeofenceControlUI(
 
       const polygonModeButton = createElement(
         "div",
-        "amplify-ctrl-create-prompt-button-polygon amplify-ctrl-create-prompt-button",
+        "geofence-ctrl-create-prompt-button-polygon geofence-ctrl-create-prompt-button",
         buttonContainer
       );
       polygonModeButton.addEventListener("click", () => {
         geofenceControl.changeMode("draw_polygon");
         // Change button selected style
-        polygonModeButton.classList.add("amplify-ctrl-create-prompt-selected");
+        polygonModeButton.classList.add("geofence-ctrl-create-prompt-selected");
         circleModeButton.classList.remove(
-          "amplify-ctrl-create-prompt-selected"
+          "geofence-ctrl-create-prompt-selected"
         );
 
         // Switch info box mode
@@ -108,7 +108,7 @@ export function AmplifyGeofenceControlUI(
       });
       polygonModeButton.innerHTML = "Custom";
 
-      circleModeButton.classList.add("amplify-ctrl-create-prompt-selected");
+      circleModeButton.classList.add("geofence-ctrl-create-prompt-selected");
 
       createCircleModeCreateContainer(_createContainer);
     } else {
@@ -119,20 +119,20 @@ export function AmplifyGeofenceControlUI(
   function createCircleModeCreateContainer(container: HTMLElement): void {
     _circleModeContainer = createElement(
       "div",
-      "amplify-ctrl-create-circle-mode-container",
+      "geofence-ctrl-create-circle-mode-container",
       container
     );
 
     const radiusTitle = createElement(
       "div",
-      "amplify-ctrl-create-circle-mode-title",
+      "geofence-ctrl-create-circle-mode-title",
       _circleModeContainer
     );
     radiusTitle.innerHTML = "Radius";
 
     const geofenceCreateInput = createElement(
       "input",
-      "amplify-ctrl-create-circle-mode-input",
+      "geofence-ctrl-create-circle-mode-input",
       _circleModeContainer
     );
     geofenceCreateInput.addEventListener(
@@ -144,38 +144,38 @@ export function AmplifyGeofenceControlUI(
   function createPolygonModeCreateContainer(container: HTMLElement): void {
     _polygonModeContainer = createElement(
       "div",
-      "amplify-ctrl-create-polygon-mode-container",
+      "geofence-ctrl-create-polygon-mode-container",
       container
     );
 
     const moreInfoContainer = createElement(
       "div",
-      "amplify-ctrl-create-polygon-mode-info-container",
+      "geofence-ctrl-create-polygon-mode-info-container",
       _polygonModeContainer
     );
     const moreInfoIcon = createElement(
       "div",
-      "amplify-ctrl-create-polygon-mode-icon",
+      "geofence-ctrl-create-polygon-mode-icon",
       moreInfoContainer
     );
 
     const letterI = createElement(
       "div",
-      "amplify-ctrl-create-polygon-mode-icon-i",
+      "geofence-ctrl-create-polygon-mode-icon-i",
       moreInfoIcon
     );
     letterI.innerHTML = "i";
 
     const moreInfo = createElement(
       "div",
-      "amplify-ctrl-create-polygon-mode-title",
+      "geofence-ctrl-create-polygon-mode-title",
       moreInfoContainer
     );
     moreInfo.innerHTML = "How it works?";
 
     const resetButton = createElement(
       "div",
-      "amplify-ctrl-create-polygon-mode-reset-button amplify-ctrl-button",
+      "geofence-ctrl-create-polygon-mode-reset-button geofence-ctrl-button",
       _polygonModeContainer
     );
     resetButton.innerHTML = "Reset";
@@ -193,13 +193,13 @@ export function AmplifyGeofenceControlUI(
   function createPolygonModeInfoPopup(container: HTMLElement): HTMLElement {
     const popupContainer = createElement(
       "div",
-      "amplify-ctrl-create-polygon-mode-popup-container",
+      "geofence-ctrl-create-polygon-mode-popup-container",
       container
     );
 
     const popup = createElement(
       "div",
-      "amplify-ctrl-create-polygon-mode-popup",
+      "geofence-ctrl-create-polygon-mode-popup",
       popupContainer
     );
 
@@ -229,19 +229,19 @@ export function AmplifyGeofenceControlUI(
   ): void {
     const popupStep = createElement(
       "div",
-      "amplify-ctrl-create-polygon-mode-popup-step",
+      "geofence-ctrl-create-polygon-mode-popup-step",
       container
     );
     const popupStepImage = createElement(
       "div",
-      "amplify-ctrl-create-polygon-mode-popup-step-image",
+      "geofence-ctrl-create-polygon-mode-popup-step-image",
       popupStep
     );
     popupStepImage.appendChild(image);
 
     const popupStepText = createElement(
       "div",
-      "amplify-ctrl-create-polygon-mode-popup-step-text",
+      "geofence-ctrl-create-polygon-mode-popup-step-text",
       popupStep
     );
     popupStepText.innerHTML = text;
@@ -260,7 +260,7 @@ export function AmplifyGeofenceControlUI(
   function createGeofenceListContainer() {
     const geofenceListContainer = createElement(
       "div",
-      "amplify-ctrl-list-container",
+      "geofence-ctrl-list-container",
       geofenceControlContainer
     );
 
@@ -268,7 +268,7 @@ export function AmplifyGeofenceControlUI(
 
     _geofenceList = createElement(
       "div",
-      "amplify-ctrl-list",
+      "geofence-ctrl-list",
       geofenceListContainer
     );
     _geofenceList.addEventListener("scroll", () => {
@@ -282,20 +282,20 @@ export function AmplifyGeofenceControlUI(
   function createGeofenceListHeader(geofenceListContainer: HTMLElement) {
     const header = createElement(
       "div",
-      "amplify-ctrl-list-header",
+      "geofence-ctrl-list-header",
       geofenceListContainer
     );
 
     _geofenceTitle = createElement(
       "div",
-      "amplify-ctrl-list-header-title",
+      "geofence-ctrl-list-header-title",
       header
     );
     _geofenceTitle.innerHTML = "Geofences (0)";
 
     _checkBoxAllAndCreateContainer = createElement(
       "div",
-      "amplify-ctrl-list-header-checkbox-create-container",
+      "geofence-ctrl-list-header-checkbox-create-container",
       header
     );
     createCheckboxAllContainer(_checkBoxAllAndCreateContainer);
@@ -304,13 +304,13 @@ export function AmplifyGeofenceControlUI(
   function createCheckboxAllContainer(geofenceListContainer: HTMLElement) {
     _checkBoxAllContainer = createElement(
       "div",
-      "amplify-ctrl-list-checkbox-all-container",
+      "geofence-ctrl-list-checkbox-all-container",
       geofenceListContainer
     );
 
     _checkboxAll = createElement(
       "input",
-      "amplify-ctrl-list-checkbox-all",
+      "geofence-ctrl-list-checkbox-all",
       _checkBoxAllContainer
     ) as HTMLInputElement;
     _checkboxAll.type = "checkbox";
@@ -326,14 +326,14 @@ export function AmplifyGeofenceControlUI(
 
     const checkboxAllText = createElement(
       "div",
-      "amplify-ctrl-list-checkbox-all-title",
+      "geofence-ctrl-list-checkbox-all-title",
       _checkBoxAllContainer
     );
     checkboxAllText.innerHTML = "Select all";
 
     _addGeofencebutton = createElement(
       "div",
-      "amplify-ctrl-list-header-add-button",
+      "geofence-ctrl-list-header-add-button",
       _checkBoxAllContainer
     ) as HTMLButtonElement;
     _addGeofencebutton.innerHTML = "+ Add";
@@ -345,11 +345,11 @@ export function AmplifyGeofenceControlUI(
   function renderListItem(geofence: Geofence): void {
     const container = createElement(
       "li",
-      "amplify-ctrl-list-item-container",
+      "geofence-ctrl-list-item-container",
       _geofenceList
     );
     container.id = `list-item-${geofence.geofenceId}`;
-    const listItem = createElement("li", "amplify-ctrl-list-item", container);
+    const listItem = createElement("li", "geofence-ctrl-list-item", container);
     listItem.addEventListener("mouseover", function () {
       geofenceControl.displayHighlightedGeofence(geofence.geofenceId);
     });
@@ -359,7 +359,7 @@ export function AmplifyGeofenceControlUI(
 
     const checkbox = createElement(
       "input",
-      "amplify-ctrl-list-item-checkbox",
+      "geofence-ctrl-list-item-checkbox",
       listItem
     );
     checkbox.id = `list-item-checkbox-${geofence.geofenceId}`;
@@ -374,26 +374,26 @@ export function AmplifyGeofenceControlUI(
 
     const geofenceTitleContainer = createElement(
       "div",
-      "amplify-ctrl-list-item-title-container",
+      "geofence-ctrl-list-item-title-container",
       listItem
     );
     const geofenceTitle = createElement(
       "div",
-      "amplify-ctrl-list-item-title",
+      "geofence-ctrl-list-item-title",
       geofenceTitleContainer
     );
     geofenceTitle.innerHTML = geofence.geofenceId;
 
     const editButton = createElement(
       "div",
-      "amplify-ctrl-edit-button",
+      "geofence-ctrl-edit-button",
       geofenceTitleContainer
     );
     editButton.addEventListener("click", function () {
       geofenceControl.editGeofence(geofence.geofenceId);
       createEditControls(container, listItem, geofence.geofenceId);
-      listItem.classList.remove("amplify-ctrl-list-item");
-      listItem.classList.add("amplify-ctrl-list-selected-item");
+      listItem.classList.remove("geofence-ctrl-list-item");
+      listItem.classList.add("geofence-ctrl-list-selected-item");
     });
     const imageIcon = new Image(15, 15);
     imageIcon.src = editIcon;
@@ -407,7 +407,7 @@ export function AmplifyGeofenceControlUI(
   ): void {
     const editContainer = createElement(
       "div",
-      "amplify-ctrl-list-item-controls",
+      "geofence-ctrl-list-item-controls",
       itemContainer
     );
 
@@ -415,22 +415,22 @@ export function AmplifyGeofenceControlUI(
 
     const rightContainer = createElement(
       "div",
-      "amplify-ctrl-list-item-controls-right",
+      "geofence-ctrl-list-item-controls-right",
       editContainer
     );
 
     const removeEditContainer = () => {
-      item.classList.remove("amplify-ctrl-list-selected-item");
-      item.classList.add("amplify-ctrl-list-item");
+      item.classList.remove("geofence-ctrl-list-selected-item");
+      item.classList.add("geofence-ctrl-list-item");
       removeElement(editContainer);
     };
 
     const cancelButton = createElement(
       "div",
-      "amplify-ctrl-cancel-button",
+      "geofence-ctrl-cancel-button",
       rightContainer
     );
-    cancelButton.classList.add("amplify-ctrl-button");
+    cancelButton.classList.add("geofence-ctrl-button");
     cancelButton.innerHTML = "Cancel";
     cancelButton.addEventListener("click", () => {
       geofenceControl.setEditingModeEnabled(false);
@@ -439,7 +439,7 @@ export function AmplifyGeofenceControlUI(
 
     const saveGeofenceButton = createElement(
       "div",
-      "amplify-ctrl-save-button amplify-ctrl-button",
+      "geofence-ctrl-save-button geofence-ctrl-button",
       rightContainer
     );
     saveGeofenceButton.addEventListener("click", async () => {
@@ -463,32 +463,32 @@ export function AmplifyGeofenceControlUI(
     hideCheckboxAllContainer();
     _addGeofenceContainer = createElement(
       "div",
-      "amplify-ctrl-add-geofence-container",
+      "geofence-ctrl-add-geofence-container",
       _checkBoxAllAndCreateContainer
     );
 
     const addGeofencePrompt = createElement(
       "div",
-      "amplify-ctrl-add-geofence",
+      "geofence-ctrl-add-geofence",
       _addGeofenceContainer
     );
 
     const nameInput = createElement(
       "input",
-      "amplify-ctrl-add-geofence-input",
+      "geofence-ctrl-add-geofence-input",
       addGeofencePrompt
     );
     (nameInput as HTMLInputElement).placeholder = "Name";
 
     const buttonContainer = createElement(
       "div",
-      "amplify-ctrl-add-geofence-buttons",
+      "geofence-ctrl-add-geofence-buttons",
       addGeofencePrompt
     );
 
     const cancelButton = createElement(
       "div",
-      "amplify-ctrl-add-geofence-cancel-button amplify-ctrl-button ",
+      "geofence-ctrl-add-geofence-cancel-button geofence-ctrl-button ",
       buttonContainer
     );
     cancelButton.innerHTML = "Cancel";
@@ -499,7 +499,7 @@ export function AmplifyGeofenceControlUI(
 
     const saveButton = createElement(
       "div",
-      "amplify-ctrl-button amplify-ctrl-save-button",
+      "geofence-ctrl-button geofence-ctrl-save-button",
       buttonContainer
     );
     saveButton.innerHTML = "Save";
@@ -516,7 +516,7 @@ export function AmplifyGeofenceControlUI(
   function createAddGeofencePromptError(error: string): void {
     const errorDiv = createElement(
       "div",
-      "amplify-ctrl-add-geofence-error",
+      "geofence-ctrl-add-geofence-error",
       _addGeofenceContainer
     );
     errorDiv.innerHTML = error;
@@ -529,10 +529,10 @@ export function AmplifyGeofenceControlUI(
   function renderDeleteButton(container: HTMLElement, id: string): void {
     const deleteButton = createElement(
       "div",
-      "amplify-ctrl-delete-button",
+      "geofence-ctrl-delete-button",
       container
     );
-    deleteButton.classList.add("amplify-ctrl-button");
+    deleteButton.classList.add("geofence-ctrl-button");
     deleteButton.addEventListener("click", function () {
       createConfirmDeleteContainer(id);
     });
@@ -544,19 +544,19 @@ export function AmplifyGeofenceControlUI(
   function createConfirmDeleteContainer(geofenceId: string): void {
     _deleteGeofenceContainer = createElement(
       "div",
-      "amplify-ctrl-delete-prompt-container",
+      "geofence-ctrl-delete-prompt-container",
       geofenceControlContainer
     );
 
     const deleteGeofencePrompt = createElement(
       "div",
-      "amplify-ctrl-delete-prompt",
+      "geofence-ctrl-delete-prompt",
       _deleteGeofenceContainer
     );
 
     const title = createElement(
       "div",
-      "amplify-ctrl-delete-geofence-title",
+      "geofence-ctrl-delete-geofence-title",
       deleteGeofencePrompt
     );
     title.innerHTML = `Are you sure you want to delete <strong>${geofenceId}</strong>?`;
@@ -570,12 +570,12 @@ export function AmplifyGeofenceControlUI(
   ): void {
     const deleteButtonsContainer = createElement(
       "div",
-      "amplify-ctrl-delete-geofence-buttons",
+      "geofence-ctrl-delete-geofence-buttons",
       container
     );
     const cancelButton = createElement(
       "div",
-      "amplify-ctrl-delete-geofence-cancel-button",
+      "geofence-ctrl-delete-geofence-cancel-button",
       deleteButtonsContainer
     );
     cancelButton.innerHTML = "Cancel";
@@ -585,7 +585,7 @@ export function AmplifyGeofenceControlUI(
 
     const confirmDeleteButton = createElement(
       "div",
-      "amplify-ctrl-delete-geofence-confirm-button",
+      "geofence-ctrl-delete-geofence-confirm-button",
       deleteButtonsContainer
     );
     confirmDeleteButton.innerHTML = "Delete";
@@ -603,19 +603,19 @@ export function AmplifyGeofenceControlUI(
   function createDeleteResultContainer(success?: boolean): void {
     _deletePopdownContainer = createElement(
       "div",
-      "amplify-ctrl-delete-popdown-container",
+      "geofence-ctrl-delete-popdown-container",
       geofenceControlContainer
     );
 
     const deletePopdown = createElement(
       "div",
-      "amplify-ctrl-delete-popdown",
+      "geofence-ctrl-delete-popdown",
       _deletePopdownContainer
     );
 
     const deletePopdownCloseButton = createElement(
       "div",
-      "amplify-ctrl-delete-popdown-close-button",
+      "geofence-ctrl-delete-popdown-close-button",
       deletePopdown
     );
     deletePopdownCloseButton.innerHTML = "X";
@@ -625,7 +625,7 @@ export function AmplifyGeofenceControlUI(
 
     const deletePopdownText = createElement(
       "div",
-      "amplify-ctrl-delete-popdown-text",
+      "geofence-ctrl-delete-popdown-text",
       deletePopdown
     );
     deletePopdownText.innerHTML = success
@@ -653,23 +653,23 @@ export function AmplifyGeofenceControlUI(
     _checkboxAll.disabled = !enabled;
 
     enabled
-      ? _addGeofencebutton.classList.remove("amplify-ctrl-noHover")
-      : _addGeofencebutton.classList.add("amplify-ctrl-noHover");
+      ? _addGeofencebutton.classList.remove("geofence-ctrl-noHover")
+      : _addGeofencebutton.classList.add("geofence-ctrl-noHover");
 
     const inputs = document.getElementsByClassName(
-      "amplify-ctrl-list-item-checkbox"
+      "geofence-ctrl-list-item-checkbox"
     );
     for (let i = 0; i < inputs.length; i++) {
       (inputs.item(i) as HTMLInputElement).disabled = !enabled;
     }
 
     const items = document.getElementsByClassName(
-      "amplify-ctrl-list-item-container"
+      "geofence-ctrl-list-item-container"
     );
     for (let i = 0; i < items.length; i++) {
       enabled
-        ? items.item(i).classList.remove("amplify-ctrl-noHover")
-        : items.item(i).classList.add("amplify-ctrl-noHover");
+        ? items.item(i).classList.remove("geofence-ctrl-noHover")
+        : items.item(i).classList.add("geofence-ctrl-noHover");
     }
   }
 

--- a/src/public/amplify-ctrl-geofence.css
+++ b/src/public/amplify-ctrl-geofence.css
@@ -1,9 +1,9 @@
-.amplify-ctrl {
+.geofence-ctrl {
   font-size: 14px;
   line-height: 18px;
 }
 
-.amplify-ctrl-button {
+.geofence-ctrl-button {
   background: unset;
   color: white;
   font-weight: bold;
@@ -12,7 +12,7 @@
 }
 
 /* List Styles */
-.amplify-ctrl-list-container {
+.geofence-ctrl-list-container {
   position: absolute;
   height: 100vh;
   left: 0;
@@ -26,16 +26,16 @@
   flex-direction: column;
 }
 
-.amplify-ctrl-list {
+.geofence-ctrl-list {
   height: 100%;
   overflow: scroll;
 }
 
-.amplify-ctrl-noHover {
+.geofence-ctrl-noHover {
   pointer-events: none;
 }
 
-.amplify-ctrl-list-header {
+.geofence-ctrl-list-header {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -44,23 +44,23 @@
   font-weight: 600;
 }
 
-.amplify-ctrl-list-header-title {
+.geofence-ctrl-list-header-title {
   border-bottom: 1px solid #e2e2e2;
   padding: 4px 12px;
 }
 
-.amplify-ctrl-list-checkbox-all-container {
+.geofence-ctrl-list-checkbox-all-container {
   display: flex;
   flex-direction: row;
   align-items: center;
   padding: 4px 12px 4px 8px;
 }
 
-.amplify-ctrl-list-checkbox-all-title {
+.geofence-ctrl-list-checkbox-all-title {
   padding-left: 8px;
 }
 
-.amplify-ctrl-list-header-add-button {
+.geofence-ctrl-list-header-add-button {
   border: none;
   background: none;
   position: absolute;
@@ -68,40 +68,40 @@
   cursor: pointer;
 }
 
-.amplify-ctrl-list-item-container {
+.geofence-ctrl-list-item-container {
   display: flex;
   flex-direction: column;
 }
 
-.amplify-ctrl-list-item {
+.geofence-ctrl-list-item {
   display: flex;
   flex-direction: row;
   align-items: center;
   padding-left: 8px;
 }
 
-.amplify-ctrl-list-selected-item {
+.geofence-ctrl-list-selected-item {
   display: flex;
   background: #003560;
   padding-top: 8px;
 }
 
-.amplify-ctrl-list-selected-item .amplify-ctrl-list-item-checkbox {
+.geofence-ctrl-list-selected-item .geofence-ctrl-list-item-checkbox {
   visibility: hidden;
 }
 
-.amplify-ctrl-list-item:hover {
+.geofence-ctrl-list-item:hover {
   background: #003560;
   color: white;
 }
 
-.amplify-ctrl-list-item:hover .amplify-ctrl-edit-button {
+.geofence-ctrl-list-item:hover .geofence-ctrl-edit-button {
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.amplify-ctrl-list-item-title-container {
+.geofence-ctrl-list-item-title-container {
   display: flex;
   justify-content: space-between;
   width: 100%;
@@ -110,14 +110,14 @@
   border-left: 1px solid #e9e9e9;
 }
 
-.amplify-ctrl-list-selected-item .amplify-ctrl-list-item-title-container {
+.geofence-ctrl-list-selected-item .geofence-ctrl-list-item-title-container {
   border: unset;
   color: white;
 }
 
 /* Delete Geofence Prompt Styles */
 
-.amplify-ctrl-delete-prompt-container {
+.geofence-ctrl-delete-prompt-container {
   position: absolute;
   background: rgba(0, 0, 0, 0.4);
   height: 100vh;
@@ -128,21 +128,21 @@
   align-items: center;
 }
 
-.amplify-ctrl-delete-prompt {
+.geofence-ctrl-delete-prompt {
   background: white;
   padding: 24px;
   border-radius: 4px;
   box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.12);
 }
 
-.amplify-ctrl-delete-geofence-buttons {
+.geofence-ctrl-delete-geofence-buttons {
   display: flex;
   justify-content: flex-end;
   padding-top: 8px;
   font-weight: bold;
 }
 
-.amplify-ctrl-delete-geofence-confirm-button {
+.geofence-ctrl-delete-geofence-confirm-button {
   background: black;
   border-radius: 4px;
   color: white;
@@ -150,7 +150,7 @@
   padding: 8px;
 }
 
-.amplify-ctrl-delete-geofence-cancel-button {
+.geofence-ctrl-delete-geofence-cancel-button {
   color: #6e6e6e;
   cursor: pointer;
   padding: 8px;
@@ -158,7 +158,7 @@
 
 /* Create Geofence Prompt Styles */
 
-.amplify-ctrl-create-prompt-container {
+.geofence-ctrl-create-prompt-container {
   position: absolute;
   height: 100vh;
   width: 100vw;
@@ -169,7 +169,7 @@
   pointer-events: none;
 }
 
-.amplify-ctrl-create-prompt {
+.geofence-ctrl-create-prompt {
   box-shadow: 0px -2px 4px rgb(0 0 0 / 12%);
   border-radius: 4px;
   background: white;
@@ -178,12 +178,12 @@
   height: 88px;
 }
 
-.amplify-ctrl-create-prompt-buttons {
+.geofence-ctrl-create-prompt-buttons {
   display: flex;
   justify-content: center;
 }
 
-.amplify-ctrl-create-prompt-button {
+.geofence-ctrl-create-prompt-button {
   color: black;
   background: white;
   border: 1px solid #d8d8d8;
@@ -192,39 +192,39 @@
   cursor: pointer;
 }
 
-.amplify-ctrl-create-prompt-selected {
+.geofence-ctrl-create-prompt-selected {
   color: white;
   background: black;
   border-color: black;
 }
 
-.amplify-ctrl-create-prompt-button-circle {
+.geofence-ctrl-create-prompt-button-circle {
   border-radius: 4px 0 0 4px;
   border-right: unset;
 }
 
-.amplify-ctrl-create-prompt-button-polygon {
+.geofence-ctrl-create-prompt-button-polygon {
   border-radius: 0 4px 4px 0;
   border-left: unset;
 }
 
-.amplify-ctrl-create-circle-mode-container {
+.geofence-ctrl-create-circle-mode-container {
   display: flex;
   flex-direction: column;
   align-items: center;
 }
 
-.amplify-ctrl-create-circle-mode-title {
+.geofence-ctrl-create-circle-mode-title {
   padding: 4px 0;
   width: 124px;
   text-align: initial;
 }
 
-.amplify-ctrl-create-circle-mode-input {
+.geofence-ctrl-create-circle-mode-input {
   width: 124px;
 }
 
-.amplify-ctrl-create-polygon-mode-container {
+.geofence-ctrl-create-polygon-mode-container {
   font-weight: 600;
   display: flex;
   flex-direction: column;
@@ -234,11 +234,11 @@
   cursor: pointer;
 }
 
-.amplify-ctrl-create-polygon-mode-info-container {
+.geofence-ctrl-create-polygon-mode-info-container {
   display: flex;
 }
 
-.amplify-ctrl-create-polygon-mode-icon {
+.geofence-ctrl-create-polygon-mode-icon {
   background: black;
   color: white;
   height: 18px;
@@ -246,25 +246,25 @@
   border-radius: 50%;
 }
 
-.amplify-ctrl-create-polygon-mode-title {
+.geofence-ctrl-create-polygon-mode-title {
   padding-left: 8px;
 }
 
-.amplify-ctrl-create-polygon-mode-reset-button {
+.geofence-ctrl-create-polygon-mode-reset-button {
   border-radius: 4px;
   background: black;
 }
 
 /* Popup container */
-.amplify-ctrl-create-polygon-mode-popup-container {
+.geofence-ctrl-create-polygon-mode-popup-container {
   position: relative;
   display: inline-block;
   cursor: pointer;
 }
 
 /* The actual popup (appears on top) */
-.amplify-ctrl-create-polygon-mode-popup-container
-  .amplify-ctrl-create-polygon-mode-popup {
+.geofence-ctrl-create-polygon-mode-popup-container
+  .geofence-ctrl-create-polygon-mode-popup {
   visibility: hidden;
   width: 560px;
   height: 100px;
@@ -285,8 +285,8 @@
 }
 
 /* Popup arrow */
-.amplify-ctrl-create-polygon-mode-popup-container
-  .amplify-ctrl-create-polygon-mode-popup::after {
+.geofence-ctrl-create-polygon-mode-popup-container
+  .geofence-ctrl-create-polygon-mode-popup::after {
   content: "";
   position: absolute;
   top: 100%;
@@ -298,11 +298,11 @@
 }
 
 /* Toggle this class when clicking on the popup container (hide and show the popup) */
-.amplify-ctrl-create-polygon-mode-popup-container .show {
+.geofence-ctrl-create-polygon-mode-popup-container .show {
   visibility: visible;
 }
 
-.amplify-ctrl-create-polygon-mode-popup-step {
+.geofence-ctrl-create-polygon-mode-popup-step {
   color: black;
   display: flex;
   flex-direction: column;
@@ -314,32 +314,32 @@
 
 /* Add Geofence Prompt Styles */
 
-.amplify-ctrl-add-geofence {
+.geofence-ctrl-add-geofence {
   background: #003560;
   display: flex;
   flex-direction: column;
 }
 
-.amplify-ctrl-add-geofence-input {
+.geofence-ctrl-add-geofence-input {
   padding: 5px 8px;
   border: 1px solid #b0b8bf;
   border-radius: 4px;
   margin: 8px;
 }
 
-.amplify-ctrl-add-geofence-buttons {
+.geofence-ctrl-add-geofence-buttons {
   display: flex;
   justify-content: flex-end;
   padding: 0 8px 8px 0px;
 }
 
 /* Delete Popup */
-.amplify-ctrl-delete-popdown-container {
+.geofence-ctrl-delete-popdown-container {
   position: absolute;
   right: 0;
 }
 
-.amplify-ctrl-delete-popdown {
+.geofence-ctrl-delete-popdown {
   padding: 12px;
   font-weight: 600;
   color: white;
@@ -347,14 +347,14 @@
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1);
 }
 
-.amplify-ctrl-delete-popdown-close-button {
+.geofence-ctrl-delete-popdown-close-button {
   text-align: right;
   cursor: pointer;
 }
 
 /* Other Styles */
 
-.amplify-ctrl-list-item-controls {
+.geofence-ctrl-list-item-controls {
   display: flex;
   flex-direction: row;
   background: #003560;
@@ -363,11 +363,11 @@
   padding-bottom: 8px;
 }
 
-.amplify-ctrl-list-item-controls-right {
+.geofence-ctrl-list-item-controls-right {
   display: flex;
 }
 
-.amplify-ctrl-edit-button {
+.geofence-ctrl-edit-button {
   margin-right: 12px;
   display: none;
   cursor: pointer;
@@ -377,7 +377,7 @@
   border-radius: 50%;
 }
 
-.amplify-ctrl-save-button {
+.geofence-ctrl-save-button {
   background: #ffffff;
   border-radius: 4px;
   padding: 4px 16px;


### PR DESCRIPTION
#### Description of changes
- Due to css included with amplify-ui the ordering of css imports will affect classes that container the word `amplify` https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/theme/css/styles.scss#L16
- After speaking with Scott seems like this was added intentionally to overly generic styling messing with `amplify` specific styling and it was assumed by the UI team that only Amplify UI would use `amplify` in class names
- Removing it on the UI side will require a lot of work (regression testing) on UI so for now we will just rename our class names
- For future proofing we can also document/recommend customers import Amplify UI css before other Amplify styles we write get loaded
  - This will also allow us to use Amplify UI CSS variables in the future

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
