### PR TITLE
fix: fix search/getSuggestions when passing in both proximity and bbox

### DIFF
--- a/__tests__/AmplifyMapLibreGeocoder.test.ts
+++ b/__tests__/AmplifyMapLibreGeocoder.test.ts
@@ -62,6 +62,24 @@ describe("AmplifyGeocoderAPI", () => {
     expect(response.features).toHaveLength(0);
   });
 
+  test("forwardGeocode prioritizes bbox over proximity value", async () => {
+    const config = {
+      query: "a map query",
+      bbox: [
+        -123.31020325000009, 37.41870932473893, -121.55239075000021,
+        38.12753577367528,
+      ],
+      promixity: [-122.431297, 37.773972],
+    };
+    await AmplifyGeocoderAPI.forwardGeocode(config);
+    expect(
+      (Geo.searchByText as jest.Mock).mock.calls[0][1].biasPosition
+    ).toBeUndefined();
+    expect(
+      (Geo.searchByText as jest.Mock).mock.calls[0][1].searchAreaConstraints
+    ).toBeDefined();
+  });
+
   test("reverseGeocode returns some values in the expected format", async () => {
     const config = {
       query: "-123, 45",
@@ -153,5 +171,25 @@ describe("AmplifyGeocoderAPI", () => {
     const response = await AmplifyGeocoderAPI.getSuggestions(config);
     expect(Geo.searchForSuggestions).toHaveBeenCalledTimes(1);
     expect(response.suggestions).toHaveLength(0);
+  });
+
+  test("forwardGeocode prioritizes bbox over proximity value", async () => {
+    const config = {
+      query: "a map query",
+      bbox: [
+        -123.31020325000009, 37.41870932473893, -121.55239075000021,
+        38.12753577367528,
+      ],
+      promixity: [-122.431297, 37.773972],
+    };
+    (Geo.searchForSuggestions as jest.Mock).mockRejectedValueOnce("an error");
+    await AmplifyGeocoderAPI.getSuggestions(config);
+    expect(
+      (Geo.searchForSuggestions as jest.Mock).mock.calls[0][1].biasPosition
+    ).toBeUndefined();
+    expect(
+      (Geo.searchForSuggestions as jest.Mock).mock.calls[0][1]
+        .searchAreaConstraints
+    ).toBeDefined();
   });
 });

--- a/src/AmplifyMapLibreGeocoder.ts
+++ b/src/AmplifyMapLibreGeocoder.ts
@@ -9,7 +9,7 @@ export const AmplifyGeocoderAPI = {
     const features = [];
     try {
       const data = await Geo.searchByText(config.query, {
-        biasPosition: config.proximity,
+        biasPosition: config.bbox ? undefined : config.proximity,
         searchAreaConstraints: config.bbox,
         countries: config.countries,
         maxResults: config.limit,
@@ -62,7 +62,7 @@ export const AmplifyGeocoderAPI = {
     const suggestions = [];
     try {
       const response = await Geo.searchForSuggestions(config.query, {
-        biasPosition: config.proximity,
+        biasPosition: config.bbox ? undefined : config.proximity,
         searchAreaConstraints: config.bbox,
         countries: config.countries,
         maxResults: config.limit,


### PR DESCRIPTION
#### Description of changes
- Amplify Geo/ Location Service would throw an error when passing in both a bounding box and a proximity parameter, fixed that by prioritizing bbox over proximity params

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added]
- [x] Relevant documentation is changed or added (and PR referenced)

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
