### PR TITLE
fix: update sourceId to be the sourceName passed into drawPoints

### DIFF
--- a/__tests__/drawPoints.test.ts
+++ b/__tests__/drawPoints.test.ts
@@ -45,7 +45,7 @@ describe("drawPoints", () => {
       MAP_STYLES.ESRI_NAVIGATION
     );
 
-    expect(addSourceMock.mock.calls[0][0]).toEqual("foo-source-points");
+    expect(addSourceMock.mock.calls[0][0]).toEqual("foo");
     expect(addSourceMock.mock.calls[0][1].data.features.length).toEqual(2);
     expect(addLayerMock).toHaveBeenCalledTimes(2);
     expect(fitBoundsMock).toHaveBeenCalledTimes(1);
@@ -66,7 +66,7 @@ describe("drawPoints", () => {
       MAP_STYLES.ESRI_NAVIGATION
     );
 
-    expect(addSourceMock.mock.calls[0][0]).toEqual("foo-source-points");
+    expect(addSourceMock.mock.calls[0][0]).toEqual("foo");
     expect(addSourceMock.mock.calls[0][1].data.features.length).toEqual(2);
     expect(addLayerMock).toHaveBeenCalledTimes(2);
     expect(fitBoundsMock).toHaveBeenCalledTimes(0);

--- a/src/drawPoints.ts
+++ b/src/drawPoints.ts
@@ -78,7 +78,7 @@ export function drawPoints(
   /*
    * Data source for features
    */
-  const sourceId = `${sourceName}-source-points`;
+  const sourceId = sourceName;
   map.addSource(sourceId, {
     type: "geojson",
     data: {


### PR DESCRIPTION
#### Description of changes
- Updates the sourceId used for `drawPoints` to be the same as the `sourceName` passed in as a parameter

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
