### PR TITLE
fix: fix saveGeofence error with empty string

### DIFF
--- a/__tests__/AmplifyGeofenceControl.test.ts
+++ b/__tests__/AmplifyGeofenceControl.test.ts
@@ -89,7 +89,7 @@ describe("AmplifyGeofenceControl", () => {
     });
 
     control._editingGeofenceId = "foobar";
-    await control.saveGeofence(control._editingGeofenceId);
+    await control.createGeofence(control._editingGeofenceId);
     expect(control._loadedGeofences["foobar"]).toBeDefined();
     expect(control._loadedGeofences["foobar"].geofenceId).toBe("foobar");
     expect(control._ui.updateGeofenceCount).toHaveBeenCalled();
@@ -113,34 +113,34 @@ describe("AmplifyGeofenceControl", () => {
 
     control._editingGeofenceId = "foobar";
     await expect(
-      control.saveGeofence(control._editingGeofenceId)
+      control.createGeofence(control._editingGeofenceId)
     ).rejects.toThrow();
   });
 
-  test("Save Geofence empty string", async () => {
+  test("Create Geofence empty string", async () => {
     const control = createMockControl();
 
-    control.saveGeofence("");
+    control.createGeofence("");
     expect(control._ui.createAddGeofencePromptError).toHaveBeenCalled();
     expect(control._ui.createAddGeofencePromptError).toHaveBeenCalledWith(
       "Geofence ID is empty."
     );
   });
 
-  test("Save Geofence undefined id", async () => {
+  test("Create Geofence undefined id", async () => {
     const control = createMockControl();
 
-    control.saveGeofence();
+    control.createGeofence();
     expect(control._ui.createAddGeofencePromptError).toHaveBeenCalled();
     expect(control._ui.createAddGeofencePromptError).toHaveBeenCalledWith(
       "Geofence ID is empty."
     );
   });
 
-  test("Save Geofence special characters", async () => {
+  test("Create Geofence special characters", async () => {
     const control = createMockControl();
 
-    control.saveGeofence("..,/.,/.,/.,.");
+    control.createGeofence("..,/.,/.,/.,.");
     expect(control._ui.createAddGeofencePromptError).toHaveBeenCalled();
     expect(control._ui.createAddGeofencePromptError).toHaveBeenCalledWith(
       "Geofence ID contains special characters."
@@ -154,14 +154,14 @@ describe("AmplifyGeofenceControl", () => {
       geometry: { polygon: [] },
     };
 
-    control.saveGeofence("foobar");
+    control.createGeofence("foobar");
     expect(control._ui.createAddGeofencePromptError).toHaveBeenCalled();
     expect(control._ui.createAddGeofencePromptError).toHaveBeenCalledWith(
       "Geofence ID already exists."
     );
   });
 
-  test("Update Geofence", async () => {
+  test("Save Geofence", async () => {
     const control = createMockControl();
 
     (Geo.saveGeofences as jest.Mock).mockReturnValueOnce({
@@ -181,7 +181,29 @@ describe("AmplifyGeofenceControl", () => {
     expect(control._loadedGeofences["foobar"].geofenceId).toBe("foobar");
   });
 
-  test("Update Geofence API error", async () => {
+  test("Save Geofence with empty string uses editing geofence id", async () => {
+    const control = createMockControl();
+
+    (Geo.saveGeofences as jest.Mock).mockReturnValueOnce({
+      successes: [
+        {
+          geofenceId: "foobar",
+          createTime: "2020-04-01T21:00:00.000Z",
+          updateTime: "2020-04-01T21:00:00.000Z",
+        },
+      ],
+      errors: [],
+    });
+
+    control._editingGeofenceId = "foobar";
+    await control.saveGeofence();
+    expect(control._loadedGeofences["foobar"]).toBeDefined();
+    expect(control._loadedGeofences["foobar"].geofenceId).toBe(
+      control._editingGeofenceId
+    );
+  });
+
+  test("Save Geofence API error", async () => {
     const control = createMockControl();
 
     (Geo.saveGeofences as jest.Mock).mockReturnValueOnce({

--- a/src/AmplifyGeofenceControl/index.ts
+++ b/src/AmplifyGeofenceControl/index.ts
@@ -134,7 +134,7 @@ export class AmplifyGeofenceControl {
     return this._container;
   }
 
-  async saveGeofence(geofenceId?: string): Promise<string | null> {
+  async createGeofence(geofenceId?: string): Promise<string | null> {
     if (!geofenceId || geofenceId.length === 0) {
       this._ui.createAddGeofencePromptError("Geofence ID is empty.");
       return;
@@ -152,9 +152,12 @@ export class AmplifyGeofenceControl {
       return;
     }
 
+    return this.saveGeofence(geofenceId);
+  }
+  async saveGeofence(geofenceId?: string): Promise<string | null> {
     const feature = this._amplifyDraw.get(this._editingGeofenceId);
 
-    const idToSave = geofenceId;
+    const idToSave = geofenceId || this._editingGeofenceId;
     const response = await Geo.saveGeofences({
       geofenceId: idToSave,
       geometry: { polygon: feature.geometry["coordinates"] },

--- a/src/AmplifyGeofenceControl/ui.ts
+++ b/src/AmplifyGeofenceControl/ui.ts
@@ -532,7 +532,7 @@ export function AmplifyGeofenceControlUI(
     saveButton.innerHTML = "Save";
     saveButton.addEventListener("click", async function () {
       clearAddGeofenceError();
-      const output = await geofenceControl.saveGeofence(
+      const output = await geofenceControl.createGeofence(
         escape((nameInput as HTMLInputElement).value)
       );
       if (output) removeAddGeofenceContainer();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2678,7 +2678,7 @@
   resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
 
-"@maplibre/maplibre-gl-geocoder@^1.1.0":
+"@maplibre/maplibre-gl-geocoder@^1.3.0":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@maplibre/maplibre-gl-geocoder/-/maplibre-gl-geocoder-1.3.1.tgz#d7c8dd27f4e574ef6f556e31dc8ec5e570adec31"
   integrity sha512-u9ue09xt70ajEZh9+k8aD7AplfObMxBrsO1WWb5ZPXiwyGdfEsW6/BMk8OF7lvtG8r23wm2sp7GTQ8DhGGSVpQ==


### PR DESCRIPTION
#### Description of changes
- Separated `createGeofence` and `saveGeofence` behavior because `saveGeofence` with empty string is used for editing behavior while creating geofence with empty string causes a validation error
- Error introduced in - https://github.com/aws-amplify/maplibre-gl-js-amplify/pull/136/files

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
