### PR TITLE
fix: fix isExistingGeofenceId logic, add resetGeofence logic to its original polygon

### DIFF
--- a/__tests__/AmplifyGeofenceControl.test.ts
+++ b/__tests__/AmplifyGeofenceControl.test.ts
@@ -49,6 +49,9 @@ describe("AmplifyGeofenceControl", () => {
           ]),
         disable: jest.fn(),
         enable: jest.fn(),
+        delete: jest.fn(),
+        add: jest.fn(),
+        drawPolygonGeofence: jest.fn(),
       };
     });
   });
@@ -368,5 +371,64 @@ describe("AmplifyGeofenceControl", () => {
 
     await control.loadMoreGeofences();
     expect(control._loadedGeofences["foobar"]).toBeUndefined();
+  });
+
+  test("Reset Existing Geofence", async () => {
+    const control = createMockControl();
+
+    (Geo.listGeofences as jest.Mock).mockReturnValueOnce({
+      entries: [
+        {
+          geofenceId: "foobar",
+          createTime: "2020-04-01T21:00:00.000Z",
+          updateTime: "2020-04-01T21:00:00.000Z",
+          geometry: { polygon: [] },
+        },
+        {
+          geofenceId: "barbaz",
+          createTime: "2020-04-01T21:00:00.000Z",
+          updateTime: "2020-04-01T21:00:00.000Z",
+          geometry: { polygon: [] },
+        },
+      ],
+    });
+
+    await control.loadInitialGeofences();
+
+    control._editingGeofenceId = "foobar";
+    await control.resetGeofence();
+
+    expect(control._amplifyDraw.delete).toHaveBeenCalled();
+    expect((control._amplifyDraw.add as jest.Mock).mock.calls[0][0].id).toEqual(
+      "foobar"
+    );
+  });
+
+  test("Reset New Geofence", async () => {
+    const control = createMockControl();
+
+    (Geo.listGeofences as jest.Mock).mockReturnValueOnce({
+      entries: [
+        {
+          geofenceId: "foobar",
+          createTime: "2020-04-01T21:00:00.000Z",
+          updateTime: "2020-04-01T21:00:00.000Z",
+          geometry: { polygon: [] },
+        },
+        {
+          geofenceId: "barbaz",
+          createTime: "2020-04-01T21:00:00.000Z",
+          updateTime: "2020-04-01T21:00:00.000Z",
+          geometry: { polygon: [] },
+        },
+      ],
+    });
+
+    await control.loadInitialGeofences();
+
+    await control.resetGeofence();
+
+    expect(control._amplifyDraw.delete).toHaveBeenCalled();
+    expect(control._amplifyDraw.drawPolygonGeofence).toHaveBeenCalled();
   });
 });

--- a/src/AmplifyGeofenceControl/index.ts
+++ b/src/AmplifyGeofenceControl/index.ts
@@ -147,7 +147,7 @@ export class AmplifyGeofenceControl {
       return;
     }
 
-    if (!isExistingGeofenceId(geofenceId, this._loadedGeofences)) {
+    if (isExistingGeofenceId(geofenceId, this._loadedGeofences)) {
       this._ui.createAddGeofencePromptError("Geofence ID already exists.");
       return;
     }
@@ -360,6 +360,17 @@ export class AmplifyGeofenceControl {
 
     if (mode === "draw_circle") {
       this._amplifyDraw.drawCircularGeofence(this._editingGeofenceId);
+    } else {
+      this._amplifyDraw.drawPolygonGeofence(this._editingGeofenceId);
+    }
+  }
+
+  resetGeofence(): void {
+    // erase existing mapbox draw content
+    this._amplifyDraw.delete(this._editingGeofenceId);
+
+    if (isExistingGeofenceId(this._editingGeofenceId, this._loadedGeofences)) {
+      this.editGeofence(this._editingGeofenceId);
     } else {
       this._amplifyDraw.drawPolygonGeofence(this._editingGeofenceId);
     }

--- a/src/AmplifyGeofenceControl/ui.ts
+++ b/src/AmplifyGeofenceControl/ui.ts
@@ -184,7 +184,7 @@ export function AmplifyGeofenceControlUI(
     );
     resetButton.innerHTML = "Reset";
     resetButton.addEventListener("click", () => {
-      geofenceControl.changeMode("draw_polygon");
+      geofenceControl.resetGeofence();
     });
 
     // Add popup onClick

--- a/src/geofenceUtils.ts
+++ b/src/geofenceUtils.ts
@@ -130,7 +130,7 @@ export const isExistingGeofenceId = (
   id: string,
   loadedGeofences: any
 ): boolean => {
-  return !doesGeofenceExist(id, loadedGeofences);
+  return doesGeofenceExist(id, loadedGeofences);
 };
 
 export const isGeofenceDisplayed = (


### PR DESCRIPTION
#### Description of changes
- Fixed `isExistingGeofenceId` logic which was actually checking for the inverse
- Added `resetGeofence` logic to its original polygon if it is resetting an existing geofence, otherwise it will reset it to a default polygon

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added]
- [x] Relevant documentation is changed or added (and PR referenced)

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
