### PR TITLE
chore: Add fit zoom on geofence display

### DIFF
--- a/__tests__/AmplifyGeofenceControl.test.ts
+++ b/__tests__/AmplifyGeofenceControl.test.ts
@@ -1,4 +1,4 @@
-import { Map as maplibreMap } from "maplibre-gl";
+import { Map, Map as maplibreMap } from "maplibre-gl";
 import { AmplifyGeofenceControl } from "../src/AmplifyGeofenceControl";
 import { getGeofenceFeatureFromPolygon } from "../src/geofenceUtils";
 import { AmplifyGeofenceControlUI } from "../src/AmplifyGeofenceControl/ui";
@@ -51,6 +51,18 @@ describe("AmplifyGeofenceControl", () => {
         enable: jest.fn(),
       };
     });
+
+    (Map as jest.Mock).mockImplementation(() => {
+      return {
+        getBounds: jest.fn().mockImplementation(() => {
+          return {
+            extend: jest.fn(),
+            contains: jest.fn(),
+          };
+        }),
+        fitBounds: jest.fn(),
+      };
+    });
   });
 
   const createMockControl = () => {
@@ -93,6 +105,7 @@ describe("AmplifyGeofenceControl", () => {
     expect(control._loadedGeofences["foobar"]).toBeDefined();
     expect(control._loadedGeofences["foobar"].geofenceId).toBe("foobar");
     expect(control._ui.updateGeofenceCount).toHaveBeenCalled();
+    expect(control._map.fitBounds).toHaveBeenCalled();
   });
 
   test("Create Geofence API error", async () => {
@@ -179,6 +192,7 @@ describe("AmplifyGeofenceControl", () => {
     await control.saveGeofence(control._editingGeofenceId);
     expect(control._loadedGeofences["foobar"]).toBeDefined();
     expect(control._loadedGeofences["foobar"].geofenceId).toBe("foobar");
+    expect(control._map.fitBounds).toHaveBeenCalled();
   });
 
   test("Save Geofence with empty string uses editing geofence id", async () => {

--- a/src/AmplifyGeofenceControl/index.ts
+++ b/src/AmplifyGeofenceControl/index.ts
@@ -60,7 +60,6 @@ export class AmplifyGeofenceControl {
     this.hideHighlightedGeofence = this.hideHighlightedGeofence.bind(this);
     this.displayGeofence = this.displayGeofence.bind(this);
     this.hideGeofence = this.hideGeofence.bind(this);
-    this.fitGeofence = this.fitGeofence.bind(this);
     this.fitAllGeofences = this.fitAllGeofences.bind(this);
   }
 
@@ -302,6 +301,8 @@ export class AmplifyGeofenceControl {
     this._displayedGeofences.push(this._loadedGeofences[geofenceId]);
     this._updateDisplayedGeofences();
     this._ui.updateCheckbox(geofenceId, true);
+
+    this.fitAllGeofences();
   }
 
   displayAllGeofences(): void {
@@ -317,23 +318,21 @@ export class AmplifyGeofenceControl {
     this.fitAllGeofences();
   }
 
-  fitGeofence(geofenceId: string): void {
-    const mapBounds = this._map.getBounds();
-    const geofence = this._loadedGeofences[geofenceId];
-    geofence.geometry.polygon[0].forEach((coord) => {
-      mapBounds.extend(coord);
-    });
-    this._map.fitBounds(mapBounds);
-  }
-
   fitAllGeofences(): void {
+    let shouldFitBounds = false;
     const mapBounds = this._map.getBounds();
-    Object.values(this._loadedGeofences).forEach(function (loadedGeofence) {
-      loadedGeofence.geometry.polygon[0].forEach((coord) => {
-        mapBounds.extend(coord);
+
+    this._displayedGeofences.forEach((geofence) => {
+      geofence.geometry.polygon[0].forEach((coord) => {
+        if (!mapBounds.contains(coord)) {
+          mapBounds.extend(coord);
+          shouldFitBounds = true;
+        }
       });
     });
-    this._map.fitBounds(mapBounds, { padding: FIT_BOUNDS_PADDING });
+
+    if (shouldFitBounds)
+      this._map.fitBounds(mapBounds, { padding: FIT_BOUNDS_PADDING });
   }
 
   hideGeofence(geofenceId: string): void {

--- a/src/AmplifyGeofenceControl/index.ts
+++ b/src/AmplifyGeofenceControl/index.ts
@@ -14,6 +14,8 @@ import { AmplifyGeofenceControlUI } from "./ui";
 import { AmplifyMapDraw } from "./AmplifyMapDraw";
 import { createElement } from "../utils";
 
+const FIT_BOUNDS_PADDING = { left: 240 }; // Default to 240px right now because of the left nav
+
 export interface AmplifyGeofenceControlOptions {
   geofenceCollectionId?: string;
 }
@@ -58,6 +60,8 @@ export class AmplifyGeofenceControl {
     this.hideHighlightedGeofence = this.hideHighlightedGeofence.bind(this);
     this.displayGeofence = this.displayGeofence.bind(this);
     this.hideGeofence = this.hideGeofence.bind(this);
+    this.fitGeofence = this.fitGeofence.bind(this);
+    this.fitAllGeofences = this.fitAllGeofences.bind(this);
   }
 
   /**********************************************************************
@@ -309,6 +313,27 @@ export class AmplifyGeofenceControl {
     Array.from(checkboxes).forEach(
       (checkbox) => (checkbox.checked = this._ui.getCheckboxAllValue())
     );
+
+    this.fitAllGeofences();
+  }
+
+  fitGeofence(geofenceId: string): void {
+    const mapBounds = this._map.getBounds();
+    const geofence = this._loadedGeofences[geofenceId];
+    geofence.geometry.polygon[0].forEach((coord) => {
+      mapBounds.extend(coord);
+    });
+    this._map.fitBounds(mapBounds, { padding: FIT_BOUNDS_PADDING });
+  }
+
+  fitAllGeofences(): void {
+    const mapBounds = this._map.getBounds();
+    Object.values(this._loadedGeofences).forEach(function (loadedGeofence) {
+      loadedGeofence.geometry.polygon[0].forEach((coord) => {
+        mapBounds.extend(coord);
+      });
+    });
+    this._map.fitBounds(mapBounds, { padding: FIT_BOUNDS_PADDING });
   }
 
   hideGeofence(geofenceId: string): void {

--- a/src/AmplifyGeofenceControl/index.ts
+++ b/src/AmplifyGeofenceControl/index.ts
@@ -323,7 +323,7 @@ export class AmplifyGeofenceControl {
     geofence.geometry.polygon[0].forEach((coord) => {
       mapBounds.extend(coord);
     });
-    this._map.fitBounds(mapBounds, { padding: FIT_BOUNDS_PADDING });
+    this._map.fitBounds(mapBounds);
   }
 
   fitAllGeofences(): void {

--- a/src/AmplifyGeofenceControl/ui.ts
+++ b/src/AmplifyGeofenceControl/ui.ts
@@ -374,7 +374,6 @@ export function AmplifyGeofenceControlUI(
     checkbox.addEventListener("click", function () {
       if ((checkbox as HTMLInputElement).checked) {
         geofenceControl.displayGeofence(geofence.geofenceId);
-        geofenceControl.fitGeofence(geofence.geofenceId);
       } else {
         geofenceControl.hideGeofence(geofence.geofenceId);
       }

--- a/src/AmplifyGeofenceControl/ui.ts
+++ b/src/AmplifyGeofenceControl/ui.ts
@@ -374,6 +374,7 @@ export function AmplifyGeofenceControlUI(
     checkbox.addEventListener("click", function () {
       if ((checkbox as HTMLInputElement).checked) {
         geofenceControl.displayGeofence(geofence.geofenceId);
+        geofenceControl.fitGeofence(geofence.geofenceId);
       } else {
         geofenceControl.hideGeofence(geofence.geofenceId);
       }


### PR DESCRIPTION
#### Description of changes
- When displaying geofences try to fit them into the current map view
  - When displaying single geofences just try to update the current map bounds to include those coordinates
  - When displaying all geofences update map bounds to include all geofences and then add some padding to the zoom

![some](https://user-images.githubusercontent.com/68032955/162845993-ebf3b1b8-fae3-49dd-8919-8a727e7e8f26.gif)
![all](https://user-images.githubusercontent.com/68032955/162846014-e4a0f4e1-b9f1-448d-9255-85a00a6e2588.gif)


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
