### PR TITLE
fix: install empty fs/path packages to fix CRA5 polyfill issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,8 @@
     "@turf/length": "^6.5.0",
     "@turf/line-slice": "^6.5.0",
     "debounce": "^1.2.1",
-    "maplibre-gl-draw-circle": "^0.0.1"
+    "fs": "npm:empty-npm-package@1.0.0",
+    "maplibre-gl-draw-circle": "^0.0.1",
+    "path": "npm:empty-npm-package@1.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5136,6 +5136,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
+"fs@npm:empty-npm-package@1.0.0", "path@npm:empty-npm-package@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/empty-npm-package/-/empty-npm-package-1.0.0.tgz#fda29eb6de5efa391f73d578697853af55f6793a"
+  integrity sha512-q4Mq/+XO7UNDdMiPpR/LIBIW1Zl4V0Z6UT9aKGqIAnBCtCb3lvZJM1KbDbdzdC8fKflwflModfjR29Nt0EpcwA==
+
 fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"


### PR DESCRIPTION
#### Description of changes
- Adding empty fs/path packages to fix the mapbox-gl-draw-circle CRA5 polyfill issue
  - Working on a fork of mapbox-gl-draw to maplibre-gl-draw which will fix this long term
- Will add e2e tests that test fs/path packages to integ tests in a separate PR

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
