### PR TITLE
fix: Fix multiple render warning

### DIFF
--- a/__tests__/drawGeofences.test.ts
+++ b/__tests__/drawGeofences.test.ts
@@ -21,9 +21,7 @@ describe("drawGeofences", () => {
 
     const mockInstance = (maplibreMap as jest.Mock).mock.instances[0];
 
-    expect(mockInstance.addSource.mock.calls[0][0]).toEqual(
-      "my-geofence-source"
-    );
+    expect(mockInstance.addSource.mock.calls[0][0]).toEqual("my-geofence");
     expect(
       mockInstance.addSource.mock.calls[0][1].data.geometry.coordinates.length
     ).toEqual(1);

--- a/src/AmplifyGeofenceControl/index.ts
+++ b/src/AmplifyGeofenceControl/index.ts
@@ -1,4 +1,4 @@
-import maplibregl, { Map } from "maplibre-gl";
+import maplibregl, { IControl, Map } from "maplibre-gl";
 import { Geo } from "@aws-amplify/geo";
 import { drawGeofences, DrawGeofencesOutput } from "../drawGeofences";
 import { Geofence } from "../types";
@@ -102,9 +102,14 @@ export class AmplifyGeofenceControl {
     this._ui.createGeofenceListContainer();
 
     // Draw the geofences source to the map so we can update it on geofences load/creation
-    this._map.on(
+    this._map.once(
       "load",
       function () {
+        // Prevents warnings on multiple re-renders, especially when rendered in react
+        if (this._map.getSource("displayedGeofences")) {
+          return;
+        }
+
         this._drawGeofencesOutput = drawGeofences(
           "displayedGeofences",
           [],

--- a/src/AmplifyGeofenceControl/index.ts
+++ b/src/AmplifyGeofenceControl/index.ts
@@ -1,4 +1,4 @@
-import maplibregl, { IControl, Map } from "maplibre-gl";
+import maplibregl, { Map } from "maplibre-gl";
 import { Geo } from "@aws-amplify/geo";
 import { drawGeofences, DrawGeofencesOutput } from "../drawGeofences";
 import { Geofence } from "../types";

--- a/src/drawGeofences.ts
+++ b/src/drawGeofences.ts
@@ -57,7 +57,7 @@ export function drawGeofences(
    * Data source for features
    * Convert data passed in as coordinates into feature data
    */
-  const sourceId = `${sourceName}-source`;
+  const sourceId = `${sourceName}`;
   map.addSource(sourceId, {
     type: "geojson",
     data: getGeofenceFeatureArray(data),


### PR DESCRIPTION
#### Description of changes
- The newer versions of CRA and CNA when run in dev mode / strict mode do two renders at the start to test the idempotency of renders, this discovered an issue when using the geofence control. When rendering the geofence control multiple times it attempts to draw the geofences in a layer with the same name multiple times coming up with a warning
- Warning pictured below
<img width="1026" alt="Screen Shot 2022-05-20 at 6 10 43 PM" src="https://user-images.githubusercontent.com/68032955/169628861-813fa6dd-a332-429b-a5a6-6ac842b21091.png">

- Fixed the error by checking first if the geofence layer has been drawn already and returning if so
- Updated drawGeofences to use the same sourceName as passed in


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added]
- [x] Relevant documentation is changed or added (and PR referenced)

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
