### PR TITLE
fix: update redentials to be grabbed from Credentials instead of Auth

### DIFF
--- a/__tests__/AmplifyMapLibreRequest.test.ts
+++ b/__tests__/AmplifyMapLibreRequest.test.ts
@@ -1,8 +1,7 @@
 import AmplifyMapLibreRequest from "../src/AmplifyMapLibreRequest";
-import { Amplify } from "@aws-amplify/core";
+import { Credentials } from "@aws-amplify/core";
 
-Amplify.Auth = {};
-Amplify.Auth.currentCredentials = jest.fn().mockImplementation(() => {
+Credentials.get = jest.fn().mockImplementation(() => {
   return {
     accessKeyId: "accessKeyId",
     sessionToken: "sessionTokenId",

--- a/__tests__/createMap.test.dom.ts
+++ b/__tests__/createMap.test.dom.ts
@@ -1,4 +1,4 @@
-import { Amplify } from "@aws-amplify/core"; 
+import { Credentials } from "@aws-amplify/core"; 
 import { Geo } from "@aws-amplify/geo";
 import type { AmazonLocationServiceMapStyle } from "@aws-amplify/geo";
  
@@ -7,8 +7,7 @@ import { createMap } from "../src/AmplifyMapLibreRequest";
 jest.mock("@aws-amplify/geo");
 
 describe('createMap', () => {
-  Amplify.Auth = {};
-  Amplify.Auth.currentCredentials = jest.fn().mockImplementation(() => {
+  Credentials.get = jest.fn().mockImplementation(() => {
     return {
       accessKeyId: "accessKeyId",
       sessionToken: "sessionTokenId",

--- a/src/AmplifyMapLibreRequest.ts
+++ b/src/AmplifyMapLibreRequest.ts
@@ -1,10 +1,10 @@
 import {
-  Amplify,
   Hub,
   ICredentials,
   Signer,
   jitteredExponentialRetry,
   getAmplifyUserAgent,
+  Credentials,
 } from "@aws-amplify/core";
 import { Geo, AmazonLocationServiceMapStyle } from "@aws-amplify/geo";
 import {
@@ -60,7 +60,7 @@ export default class AmplifyMapLibreRequest {
     const defaultMap = Geo.getDefaultMap() as AmazonLocationServiceMapStyle;
 
     const amplifyRequest = new AmplifyMapLibreRequest(
-      await Amplify.Auth.currentCredentials(),
+      await Credentials.get(),
       region || defaultMap.region
     );
     const transformRequest = amplifyRequest.transformRequest;
@@ -75,7 +75,7 @@ export default class AmplifyMapLibreRequest {
 
   refreshCredentials = async (): Promise<void> => {
     try {
-      this.credentials = await Amplify.Auth.currentCredentials();
+      this.credentials = await Credentials.get();
     } catch (e) {
       console.error(`Failed to refresh credentials: ${e}`);
       throw e;


### PR DESCRIPTION
#### Description of changes
- Updated to use `Credentials` instead of `Amplify.auth`
  - Required as aws amplify is removing the usage of the singleton Amplify usage to get rid of `sideEffects` in their next release

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
