### PR TITLE
perf: upgrade peerDeps aws-amplify-core to 5.x.x and aws-amplify geo …

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     ]
   },
   "devDependencies": {
-    "@aws-amplify/core": "^4.7.8",
-    "@aws-amplify/geo": "^1.3.20",
+    "@aws-amplify/core": "5.0.0",
+    "@aws-amplify/geo": "2.0.0",
     "@babel/preset-env": "^7.16.4",
     "@commitlint/cli": "^16.2.1",
     "@commitlint/config-conventional": "^16.2.1",
@@ -91,8 +91,8 @@
     "typescript": "^4.3.2"
   },
   "peerDependencies": {
-    "@aws-amplify/core": "4.x.x || 5.x.x",
-    "@aws-amplify/geo": "^1.3.20 || 2.x.x",
+    "@aws-amplify/core": "5.x.x",
+    "@aws-amplify/geo": "2.x.x",
     "maplibre-gl": "1.x.x || 2.x.x"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,29 +10,31 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-amplify/core@4.7.8", "@aws-amplify/core@^4.7.8":
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/core/-/core-4.7.8.tgz#6a35e08938ec1c903fb443c1e1b89b71bce5affe"
-  integrity sha512-mPBB0PXZf6AgX2uBhz4NyhGYEk+XD9YNZLmpMNw8WWiKOcoh4yZCJtGyQ7godGbqNnHTxHVzQpq37AU/U8T1TA==
+"@aws-amplify/core@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/core/-/core-5.0.0.tgz#8d309320719f5b90880f1cf748f2d260a4acb215"
+  integrity sha512-mzgGJ2eelkJpTFIY0H80rqOy9ysKRt1q8Zle3qvCDg0zUIxmx+s2lZd5gwEfDGcwVkj4nI7cGdwZoBo/vGLm5Q==
   dependencies:
-    "@aws-crypto/sha256-js" "1.0.0-alpha.0"
+    "@aws-crypto/sha256-js" "1.2.2"
     "@aws-sdk/client-cloudwatch-logs" "3.6.1"
     "@aws-sdk/client-cognito-identity" "3.6.1"
     "@aws-sdk/credential-provider-cognito-identity" "3.6.1"
     "@aws-sdk/types" "3.6.1"
     "@aws-sdk/util-hex-encoding" "3.6.1"
+    tslib "^1.8.0"
     universal-cookie "^4.0.4"
     zen-observable-ts "0.8.19"
 
-"@aws-amplify/geo@^1.3.20":
-  version "1.3.20"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/geo/-/geo-1.3.20.tgz#dea4e3fd5078e5aea9e480e0be5fcb8075da2405"
-  integrity sha512-FDRMXwqJNOTF1ossQtHTWukJc/rOUhztufIUvOzoySdIEiMagYdTFrI7llWRWyOJaZ0HCjw7BPRQWWajH4YwyA==
+"@aws-amplify/geo@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/geo/-/geo-2.0.0.tgz#dd520b647d93847e9e3886b4de0de002c0ebf793"
+  integrity sha512-JFn1Ubvnus0FUB61IN9P6PNHASsJbO9ab84wqCNSTzK1kSEivSpCFfLS/Om/IP2eaVh0aYnEYrAriuQbfSObig==
   dependencies:
-    "@aws-amplify/core" "4.7.8"
+    "@aws-amplify/core" "5.0.0"
     "@aws-sdk/client-location" "3.186.0"
     "@turf/boolean-clockwise" "6.5.0"
     camelcase-keys "6.2.2"
+    tslib "^1.8.0"
 
 "@aws-crypto/ie11-detection@^1.0.0":
   version "1.0.0"
@@ -75,14 +77,14 @@
     "@aws-sdk/util-locate-window" "^3.0.0"
     tslib "^1.11.1"
 
-"@aws-crypto/sha256-js@1.0.0-alpha.0":
-  version "1.0.0-alpha.0"
-  resolved "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0-alpha.0.tgz"
-  integrity sha512-GidX2lccEtHZw8mXDKJQj6tea7qh3pAnsNSp1eZNxsN4MMu2OvSraPSqiB1EihsQkZBMg0IiZPpZHoACUX/QMQ==
+"@aws-crypto/sha256-js@1.2.2", "@aws-crypto/sha256-js@^1.0.0", "@aws-crypto/sha256-js@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz"
+  integrity sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==
   dependencies:
-    "@aws-sdk/types" "^1.0.0-alpha.0"
-    "@aws-sdk/util-utf8-browser" "^1.0.0-alpha.0"
-    tslib "^1.9.3"
+    "@aws-crypto/util" "^1.2.2"
+    "@aws-sdk/types" "^3.1.0"
+    tslib "^1.11.1"
 
 "@aws-crypto/sha256-js@2.0.0":
   version "2.0.0"
@@ -90,15 +92,6 @@
   integrity sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==
   dependencies:
     "@aws-crypto/util" "^2.0.0"
-    "@aws-sdk/types" "^3.1.0"
-    tslib "^1.11.1"
-
-"@aws-crypto/sha256-js@^1.0.0", "@aws-crypto/sha256-js@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz"
-  integrity sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==
-  dependencies:
-    "@aws-crypto/util" "^1.2.2"
     "@aws-sdk/types" "^3.1.0"
     tslib "^1.11.1"
 
@@ -936,11 +929,6 @@
   resolved "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz"
   integrity sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==
 
-"@aws-sdk/types@^1.0.0-alpha.0":
-  version "1.0.0-rc.10"
-  resolved "https://registry.npmjs.org/@aws-sdk/types/-/types-1.0.0-rc.10.tgz"
-  integrity sha512-9gwhYnkTNuYZ+etCtM4T8gjpZ0SWSXbzQxY34UjSS+dt3C/UnbX0J22tMahp/9Z1yCa9pihtXrkD+nO2xn7nVQ==
-
 "@aws-sdk/types@^3.1.0":
   version "3.110.0"
   resolved "https://registry.npmjs.org/@aws-sdk/types/-/types-3.110.0.tgz"
@@ -1166,13 +1154,6 @@
   version "3.6.1"
   resolved "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz"
   integrity sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==
-  dependencies:
-    tslib "^1.8.0"
-
-"@aws-sdk/util-utf8-browser@^1.0.0-alpha.0":
-  version "1.0.0-rc.8"
-  resolved "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-1.0.0-rc.8.tgz"
-  integrity sha512-clncPMJ23rxCIkZ9LoUC8SowwZGxWyN2TwRb0XvW/Cv9EavkRgRCOrCpneGyC326lqtMKx36onnpaSRHxErUYw==
   dependencies:
     tslib "^1.8.0"
 


### PR DESCRIPTION
…to 2.x.x

BREAKING CHANGE: upgraded peerDeps for amplify core and geo

#### Description of changes
- Upgrades peerDeps for @aws-amplify/core and @aws-amplify/geo to 5.x.x and 2.x.x respectively

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
