### PR TITLE
fix: fix infinite refresh occuring when app does not allow guest access

### DIFF
--- a/src/AmplifyMapLibreRequest.ts
+++ b/src/AmplifyMapLibreRequest.ts
@@ -87,7 +87,8 @@ export default class AmplifyMapLibreRequest {
 
       // Refresh credentials on a timer because HubEvents do not trigger on credential refresh currently
       this.activeTimeout && clearTimeout(this.activeTimeout);
-      if (this.credentials.expiration) {
+      // Refresh credentials when expiration time is later than now
+      if (this.credentials.expiration.getTime() > (new Date()).getTime()) {
         const expiration = new Date(this.credentials.expiration);
         const timeout = expiration.getTime() - new Date().getTime() - 10000; // Adds a 10 second buffer time before the next refresh
         this.activeTimeout = window.setTimeout(

--- a/src/AmplifyMapLibreRequest.ts
+++ b/src/AmplifyMapLibreRequest.ts
@@ -7,11 +7,7 @@ import {
   Credentials,
 } from "@aws-amplify/core";
 import { Geo, AmazonLocationServiceMapStyle } from "@aws-amplify/geo";
-import {
-  Map as MaplibreMap,
-  RequestParameters,
-  MapOptions,
-} from "maplibre-gl";
+import { Map as MaplibreMap, RequestParameters, MapOptions } from "maplibre-gl";
 import { urlEncodePeriods } from "./utils";
 
 /**
@@ -19,7 +15,9 @@ import { urlEncodePeriods } from "./utils";
  * We keep the property optional here since we default to the map name for the maplibre style field and
  * it maintains backwards compatibility with the upgrade to maplibre v2.
  */
-interface CreateMapOptions extends Omit<MapOptions, 'style'>, Partial<Pick<MapOptions, 'style'>> {
+interface CreateMapOptions
+  extends Omit<MapOptions, "style">,
+    Partial<Pick<MapOptions, "style">> {
   region?: string;
   mapConstructor?: typeof MaplibreMap;
 }
@@ -89,12 +87,14 @@ export default class AmplifyMapLibreRequest {
 
       // Refresh credentials on a timer because HubEvents do not trigger on credential refresh currently
       this.activeTimeout && clearTimeout(this.activeTimeout);
-      const expiration = new Date(this.credentials.expiration);
-      const timeout = expiration.getTime() - new Date().getTime() - 10000; // Adds a 10 second buffer time before the next refresh
-      this.activeTimeout = window.setTimeout(
-        this.refreshCredentialsWithRetry,
-        timeout
-      );
+      if (this.credentials.expiration) {
+        const expiration = new Date(this.credentials.expiration);
+        const timeout = expiration.getTime() - new Date().getTime() - 10000; // Adds a 10 second buffer time before the next refresh
+        this.activeTimeout = window.setTimeout(
+          this.refreshCredentialsWithRetry,
+          Math.min(timeout, 3600000) // Set timeout to an hour if we somehow don't have a value for timeout
+        );
+      }
     } catch (e) {
       console.error(`Failed to refresh credentials: ${e}`);
     }


### PR DESCRIPTION
#### Description of changes
- When user refreshes credentials and receives an error (often can occur if signing out and not having guest access) the credentials object will be set to some error value without an expiration date. This was causing set timeout to be called instantly as we were not passing a number
  - https://github.com/aws-amplify/amplify-ui/issues/3367
- Added a check to ensure that expiration is a number that exists 
- Still needs unit and integration tests

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
