### PR TITLE
fix: append query params to existing query params if any

### DIFF
--- a/__tests__/AmplifyMapLibreRequest.test.ts
+++ b/__tests__/AmplifyMapLibreRequest.test.ts
@@ -75,6 +75,10 @@ describe("AmplifyMapLibreRequest", () => {
     const amplifyRequest = new AmplifyMapLibreRequest(mockCreds, "us-west-2");
 
     let request = amplifyRequest.transformRequest("http://maps.geo.us-east-1.amazonaws.com?tsi=0", "any");
+    const queryStringStartIndex = request.url.indexOf('?');
+    const anotherQueryStringStartIndexExists = request.url.indexOf('?', queryStringStartIndex + 1) !== -1;
+    expect(anotherQueryStringStartIndexExists).toEqual(false);
+
     let searchParams = new URL(request.url).searchParams;
     expect(searchParams.has('tsi')).toBe(true);
     expect(searchParams.has('x-amz-user-agent')).toBe(true);

--- a/__tests__/AmplifyMapLibreRequest.test.ts
+++ b/__tests__/AmplifyMapLibreRequest.test.ts
@@ -73,6 +73,7 @@ describe("AmplifyMapLibreRequest", () => {
       expiration: new Date(),
     };
     const amplifyRequest = new AmplifyMapLibreRequest(mockCreds, "us-west-2");
+
     let request = amplifyRequest.transformRequest("http://maps.geo.us-east-1.amazonaws.com?tsi=0", "any");
     let searchParams = new URL(request.url).searchParams;
     expect(searchParams.has('tsi')).toBe(true);
@@ -80,6 +81,17 @@ describe("AmplifyMapLibreRequest", () => {
 
     request = amplifyRequest.transformRequest("http://maps.geo.us-east-1.amazonaws.com?", "any");
     searchParams = new URL(request.url).searchParams;
+    expect(searchParams.has('x-amz-user-agent')).toBe(true);
+
+    request = amplifyRequest.transformRequest("http://maps.geo.us-east-1.amazonaws.com?param1=1&", "any");
+    searchParams = new URL(request.url).searchParams;
+    expect(searchParams.has('param1')).toBe(true);
+    expect(searchParams.has('x-amz-user-agent')).toBe(true);
+
+    request = amplifyRequest.transformRequest("http://maps.geo.us-east-1.amazonaws.com?param1=1&param2=2", "any");
+    searchParams = new URL(request.url).searchParams;
+    expect(searchParams.has('param1')).toBe(true);
+    expect(searchParams.has('param2')).toBe(true);
     expect(searchParams.has('x-amz-user-agent')).toBe(true);
   });
 

--- a/__tests__/AmplifyMapLibreRequest.test.ts
+++ b/__tests__/AmplifyMapLibreRequest.test.ts
@@ -63,6 +63,26 @@ describe("AmplifyMapLibreRequest", () => {
     expect(request.url).toContain("x-amz-user-agent");
   });
 
+  test("transformRequest appends query params to existing query params if any", () => {
+    const mockCreds = {
+      accessKeyId: "accessKeyId",
+      sessionToken: "sessionTokenId",
+      secretAccessKey: "secretAccessKey",
+      identityId: "identityId",
+      authenticated: true,
+      expiration: new Date(),
+    };
+    const amplifyRequest = new AmplifyMapLibreRequest(mockCreds, "us-west-2");
+    let request = amplifyRequest.transformRequest("http://maps.geo.us-east-1.amazonaws.com?tsi=0", "any");
+    let searchParams = new URL(request.url).searchParams;
+    expect(searchParams.has('tsi')).toBe(true);
+    expect(searchParams.has('x-amz-user-agent')).toBe(true);
+
+    request = amplifyRequest.transformRequest("http://maps.geo.us-east-1.amazonaws.com?", "any");
+    searchParams = new URL(request.url).searchParams;
+    expect(searchParams.has('x-amz-user-agent')).toBe(true);
+  });
+
   test("transformRequest queries Amazon Location Service for Style requests and adds sigv4 auth", () => {
     const mockCreds = {
       accessKeyId: "accessKeyId",

--- a/src/AmplifyMapLibreRequest.ts
+++ b/src/AmplifyMapLibreRequest.ts
@@ -121,7 +121,8 @@ export default class AmplifyMapLibreRequest {
       // only sign AWS requests (with the signature as part of the query string)
       const urlWithUserAgent =
         url +
-        `?x-amz-user-agent=${encodeURIComponent(
+        (url.search.length === 0 ? '?' : '&') +
+        `x-amz-user-agent=${encodeURIComponent(
           urlEncodePeriods(getAmplifyUserAgent())
         )}`;
       return {


### PR DESCRIPTION
#### Description of changes
Append query params to existing query params if any

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Maplibre will parse the urls defined in the style-descriptor file and fetch the tiles. However, in the transform function, query params were added to url starting with `x-amz-user-agent` as the first param. This is an issue when the input url already has a query param. With the fix, `x-amz-user-agent` is appended to existing query params.
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Tested with raster tiles fetched from style descriptor

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
