### PR TITLE
fix: temporarily pin @maplibre/maplibre-gl-geocoder package to previo…

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "dependencies": {
     "@mapbox/mapbox-gl-draw": "^1.3.0",
-    "@maplibre/maplibre-gl-geocoder": "^1.5.0",
+    "@maplibre/maplibre-gl-geocoder": "1.5.0",
     "@turf/along": "^6.5.0",
     "@turf/circle": "^6.5.0",
     "@turf/distance": "^6.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2426,7 +2426,7 @@
   resolved "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz"
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
 
-"@maplibre/maplibre-gl-geocoder@^1.5.0":
+"@maplibre/maplibre-gl-geocoder@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@maplibre/maplibre-gl-geocoder/-/maplibre-gl-geocoder-1.5.0.tgz#6b413525b361b4759df0fd17429e12b78f03b3a4"
   integrity sha512-PsAbV7WFIOu5QYZne95FiXoV7AV1/6ULMjQxgInhZ5DdB0hDLjciQPegnyDgkzI8JfeqoUMZVS/MglZnSZYhyQ==


### PR DESCRIPTION
…us version

#### Description of changes
`@maplibre/maplibre-gl-geocoder@1.6.0` is breaking the `@aws-amplify/ui-react-geo` package. We validated that 1.5.0 still works so temporarily pin to this version while we investigate 
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
