### PR TITLE
chore: upgrade CI to Node 20 and upgrade various github actions

### DIFF
--- a/.github/actions/load-verdaccio-with-maplibre-gl-js-amplify/action.yml
+++ b/.github/actions/load-verdaccio-with-maplibre-gl-js-amplify/action.yml
@@ -8,7 +8,7 @@ runs:
   steps:
     - name: Start verdaccio
       run: |
-        npx verdaccio@5.25.0 &
+        npx verdaccio@6.0.5 &
         while ! nc -z localhost 4873; do
           echo "Verdaccio not running yet"
           sleep 1
@@ -17,7 +17,7 @@ runs:
         # Run your commands after verdaccio is up and running
         echo "Verdaccio is up and running, proceeding with the script..."
       shell: bash
-    - name: Install and run npm-cli-login
+    - name: Authenticate with Verdaccio
       shell: bash
       env:
         NPM_REGISTRY: http://localhost:4873/
@@ -25,9 +25,14 @@ runs:
         NPM_PASS: verdaccio
         NPM_EMAIL: verdaccio@amplify.js
       run: |
-        npm i -g npm-cli-adduser
-        npm-cli-adduser
-        sleep 1
+        TOKEN=$(curl -X PUT \
+        -H "Content-Type: application/json" \
+        -d "{\"name\": \"$NPM_USER\", \"password\": \"$NPM_PASS\"}" \
+        $NPM_REGISTRY-/user/org.couchdb.user:$NPM_USER | jq -r '.token')
+
+        echo "registry=$NPM_REGISTRY
+        //localhost:4873/:_authToken=$TOKEN" > ~/.npmrc
+
     - name: Configure registry and git
       shell: bash
       working-directory: ./maplibre-gl-js-amplify

--- a/.github/actions/node-and-build/action.yml
+++ b/.github/actions/node-and-build/action.yml
@@ -9,13 +9,13 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Setup Node.js 18
-      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0 https://github.com/actions/setup-node/commit/64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+    - name: Setup Node.js 20
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0 https://github.com/actions/setup-node/commit/cdca7365b2dadb8aad0a33bc7601856ffabcc48e
       with:
-        node-version: 18.20.2
+        node-version: 20
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
-    - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+    - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3 https://github.com/actions/cache/commit/5a3ec84eff668545956fd18022155c47e93e2684
       id: cache-build-artifacts
       with:
         path: |

--- a/.github/actions/setup-samples-staging/action.yml
+++ b/.github/actions/setup-samples-staging/action.yml
@@ -12,7 +12,7 @@ runs:
   using: 'composite'
   steps:
     - name: Create cache
-      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1 https://github.com/actions/cache/commit/88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3 https://github.com/actions/cache/commit/5a3ec84eff668545956fd18022155c47e93e2684
       id: cache-samples-staging-build
       with:
         key: aws-amplify-js-samples-staging-build-${{ github.sha }}
@@ -22,7 +22,7 @@ runs:
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
     - name: Checkout staging repo
-      uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         repository: ${{ github.repository_owner }}/amplify-js-samples-staging
         path: amplify-js-samples-staging

--- a/.github/workflows/callable-e2e-test.yml
+++ b/.github/workflows/callable-e2e-test.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           path: maplibre-gl-js-amplify
       - name: Setup node and build the repository

--- a/.github/workflows/callable-e2e-tests.yml
+++ b/.github/workflows/callable-e2e-tests.yml
@@ -2,10 +2,7 @@
 
 name: E2E Tests
 
-on:
-  push:
-    branches: ['chore/upgrade-node-to-20']
-# on: workflow_call
+on: workflow_call
 
 jobs:
   e2e-prep:

--- a/.github/workflows/callable-e2e-tests.yml
+++ b/.github/workflows/callable-e2e-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           path: maplibre-gl-js-amplify
       - name: Read integ config files

--- a/.github/workflows/callable-e2e-tests.yml
+++ b/.github/workflows/callable-e2e-tests.yml
@@ -2,7 +2,10 @@
 
 name: E2E Tests
 
-on: workflow_call
+on:
+  push:
+    branches: ['chore/upgrade-node-to-20']
+# on: workflow_call
 
 jobs:
   e2e-prep:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@d23060145bc9131d50558d5d4185494a20208101 # v2.12.5 https://github.com/github/codeql-action/commit/d23060145bc9131d50558d5d4185494a20208101

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,16 +8,16 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.20.2]
+        node-version: [20.x]
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 2
 
       - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0 https://github.com/actions/setup-node/commit/64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0 https://github.com/actions/setup-node/commit/cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [e2e]
     steps:
-      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Use Node.js 18 x64
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0 https://github.com/actions/setup-node/commit/64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+      - name: Use Node.js 20 x64
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0 https://github.com/actions/setup-node/commit/cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
-          node-version: 18.20.2
+          node-version: 20
           architecture: x64
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
#### Description of changes
- align Verdaccio version and usage with changes from https://github.com/aws-amplify/amplify-js/pull/14273
- upgrade Node from 18.20.2 to 20
- upgrade `actions/setup-node` to v4.3.0
- upgrade `actions/checkout` to v4.2.2
- upgrade `actions/cache` to v4.2.3

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- e2e action run using changes: https://github.com/aws-amplify/maplibre-gl-js-amplify/actions/runs/14049852479

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
