### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/callable-e2e-test.yml
+++ b/.github/workflows/callable-e2e-test.yml
@@ -40,6 +40,9 @@ env:
   CYPRESS_GOOGLE_CLIENT_SECRET: ${{ secrets.CYPRESS_GOOGLE_CLIENT_SECRET }}
   CYPRESS_GOOGLE_REFRESH_TOKEN: ${{ secrets.CYPRESS_GOOGLE_REFRESH_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   e2e-test:
     name: E2E ${{ inputs.test_name }}

--- a/.github/workflows/callable-e2e-tests.yml
+++ b/.github/workflows/callable-e2e-tests.yml
@@ -4,6 +4,9 @@ name: E2E Tests
 
 on: workflow_call
 
+permissions:
+  contents: read
+
 jobs:
   e2e-prep:
     name: Get required configs to run e2e tests

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,9 @@ name: Running Code Coverage
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,10 @@ on:
       - geo
       - next-geo
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   e2e:
     secrets: inherit


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.