### PR TITLE
fix: escape user-controlled data in innerHTML to prevent XSS

### DIFF
--- a/__tests__/xss-prevention.test.ts
+++ b/__tests__/xss-prevention.test.ts
@@ -1,0 +1,211 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * XSS Prevention Tests
+ *
+ * Verifies that user-controlled data (geofenceId, GeoJSON feature
+ * properties) cannot inject HTML or JavaScript when rendered
+ * through the UI or popup components.
+ */
+
+import { AmplifyGeofenceControlUI } from '../src/AmplifyGeofenceControl/ui';
+import { getPopupRenderFunction } from '../src/popupRender';
+import { escapeHtml } from '../src/utils';
+
+// XSS payloads to test against
+const XSS_PAYLOADS = [
+  '<script>alert(1)</script>',
+  '<img src=x onerror=alert(1)>',
+  '<svg onload=alert(1)>',
+  '" onmouseover="alert(1)',
+  "' onmouseover='alert(1)",
+  '<iframe src="javascript:alert(1)">',
+  '<body onload=alert(1)>',
+  '<a href="javascript:alert(1)">click</a>',
+  '<div style="background:url(javascript:alert(1))">',
+  '"><script>alert(document.cookie)</script>',
+];
+
+/**
+ * Helper: parse HTML and verify no dangerous elements or event handlers exist.
+ */
+function assertNoInjectedElements(html: string): void {
+  const div = document.createElement('div');
+  div.innerHTML = html;
+
+  const dangerous = div.querySelectorAll(
+    'script, img, svg, iframe, body, a[href^="javascript"]'
+  );
+  expect(dangerous.length).toBe(0);
+
+  div.querySelectorAll('*').forEach((el) => {
+    el.getAttributeNames().forEach((attr) => {
+      expect(attr.toLowerCase()).not.toMatch(/^on/);
+    });
+  });
+}
+
+describe('escapeHtml utility', () => {
+  test('escapes all HTML special characters', () => {
+    const input = '<script>"alert(1)"&\'test\'</script>';
+    const result = escapeHtml(input);
+    expect(result).toBe(
+      '&lt;script&gt;&quot;alert(1)&quot;&amp;&#39;test&#39;&lt;/script&gt;'
+    );
+  });
+
+  test('returns safe string for each XSS payload', () => {
+    for (const payload of XSS_PAYLOADS) {
+      const result = escapeHtml(payload);
+      expect(result).not.toContain('<');
+      expect(result).not.toContain('>');
+    }
+  });
+
+  test('does not alter plain text', () => {
+    expect(escapeHtml('hello world')).toBe('hello world');
+    expect(escapeHtml('myGeofence123')).toBe('myGeofence123');
+    expect(escapeHtml('')).toBe('');
+  });
+});
+
+describe('AmplifyGeofenceControlUI XSS prevention', () => {
+  let container: HTMLElement;
+  let ui: ReturnType<typeof AmplifyGeofenceControlUI>;
+  let mockGeofenceControl: Record<string, jest.Mock>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    mockGeofenceControl = {
+      changeMode: jest.fn(),
+      resetGeofence: jest.fn(),
+      loadMoreGeofences: jest.fn(),
+      displayAllGeofences: jest.fn(),
+      hideAllGeofences: jest.fn(),
+      displayGeofence: jest.fn(),
+      fitGeofence: jest.fn(),
+      hideGeofence: jest.fn(),
+      displayHighlightedGeofence: jest.fn(),
+      hideHighlightedGeofence: jest.fn(),
+      editGeofence: jest.fn(),
+      setEditingModeEnabled: jest.fn(),
+      saveGeofence: jest.fn(),
+      addEditableGeofence: jest.fn(),
+      createGeofence: jest.fn(),
+      deleteGeofence: jest.fn(),
+      updateInputRadius: jest.fn(),
+    };
+
+    ui = AmplifyGeofenceControlUI(mockGeofenceControl, container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  describe('renderListItem - geofenceId XSS', () => {
+    beforeEach(() => {
+      ui.createGeofenceListContainer();
+    });
+
+    test.each(XSS_PAYLOADS)(
+      'geofenceId "%s" is rendered as text, not HTML',
+      (payload) => {
+        ui.renderListItem({
+          geofenceId: payload,
+          geometry: { polygon: [] },
+        });
+
+        const titleEl = container.querySelector(
+          '.geofence-ctrl-list-item-title'
+        );
+        expect(titleEl).not.toBeNull();
+        expect(titleEl.textContent).toBe(payload);
+        const dangerous = titleEl.querySelectorAll(
+          'script, img, svg, iframe, a[href^="javascript"]'
+        );
+        expect(dangerous.length).toBe(0);
+      }
+    );
+  });
+});
+
+describe('popupRender XSS prevention', () => {
+  const defaultOptions = {};
+
+  test.each(XSS_PAYLOADS)(
+    'title from place_name "%s" is HTML-escaped in popup',
+    (payload) => {
+      const renderFn = getPopupRenderFunction('test-layer', defaultOptions);
+      const feature = {
+        type: 'Feature' as const,
+        geometry: { type: 'Point' as const, coordinates: [0, 0] },
+        properties: { place_name: payload },
+      };
+
+      const html = renderFn(feature);
+      assertNoInjectedElements(html);
+    }
+  );
+
+  test.each(XSS_PAYLOADS)(
+    'title property "%s" is HTML-escaped in popup',
+    (payload) => {
+      const renderFn = getPopupRenderFunction('test-layer', defaultOptions);
+      const feature = {
+        type: 'Feature' as const,
+        geometry: { type: 'Point' as const, coordinates: [0, 0] },
+        properties: { title: payload, address: '123 Main St' },
+      };
+
+      const html = renderFn(feature);
+      assertNoInjectedElements(html);
+    }
+  );
+
+  test.each(XSS_PAYLOADS)(
+    'address property "%s" is HTML-escaped in popup',
+    (payload) => {
+      const renderFn = getPopupRenderFunction('test-layer', defaultOptions);
+      const feature = {
+        type: 'Feature' as const,
+        geometry: { type: 'Point' as const, coordinates: [0, 0] },
+        properties: { title: 'Safe Title', address: payload },
+      };
+
+      const html = renderFn(feature);
+      assertNoInjectedElements(html);
+    }
+  );
+
+  test('legitimate text renders correctly', () => {
+    const renderFn = getPopupRenderFunction('test-layer', defaultOptions);
+    const feature = {
+      type: 'Feature' as const,
+      geometry: { type: 'Point' as const, coordinates: [-122.4, 37.8] },
+      properties: { title: 'Golden Gate Bridge', address: 'San Francisco, CA' },
+    };
+
+    const html = renderFn(feature);
+    expect(html).toContain('Golden Gate Bridge');
+    expect(html).toContain('San Francisco, CA');
+  });
+
+  test('place_name with commas splits correctly and escapes both parts', () => {
+    const renderFn = getPopupRenderFunction('test-layer', defaultOptions);
+    const feature = {
+      type: 'Feature' as const,
+      geometry: { type: 'Point' as const, coordinates: [0, 0] },
+      properties: {
+        place_name: '<script>alert(1)</script>, <img src=x onerror=alert(1)>',
+      },
+    };
+
+    const html = renderFn(feature);
+    assertNoInjectedElements(html);
+  });
+});

--- a/src/AmplifyGeofenceControl/ui.ts
+++ b/src/AmplifyGeofenceControl/ui.ts
@@ -1,6 +1,6 @@
 import { Geofence } from '../types';
 import { debounce } from 'debounce';
-import { createElement, removeElement } from '../utils';
+import { createElement, escapeHtml, removeElement } from '../utils';
 import { createErrorIcon } from './icons';
 import {
   createEditIcon,
@@ -405,7 +405,7 @@ export function AmplifyGeofenceControlUI(
       'geofence-ctrl-list-item-title',
       geofenceTitleContainer
     );
-    geofenceTitle.innerHTML = geofence.geofenceId;
+    geofenceTitle.innerHTML = escapeHtml(geofence.geofenceId);
 
     const editButton = createElement(
       'div',
@@ -604,7 +604,9 @@ export function AmplifyGeofenceControlUI(
       'geofence-ctrl-delete-geofence-title',
       deleteGeofencePrompt
     );
-    title.innerHTML = `Are you sure you want to delete <strong>${geofenceId}</strong>?`;
+    title.innerHTML = `Are you sure you want to delete <strong>${escapeHtml(
+      geofenceId
+    )}</strong>?`;
 
     createDeleteButtonsContainer(deleteGeofencePrompt, geofenceId);
   }

--- a/src/popupRender.ts
+++ b/src/popupRender.ts
@@ -1,5 +1,5 @@
 import { Feature, Point, Position } from 'geojson';
-import { strHasLength } from './utils';
+import { escapeHtml, strHasLength } from './utils';
 import { PopupRenderFunction, UnclusteredOptions } from './types';
 import { COLOR_BLACK, COLOR_WHITE, POPUP_BORDER_COLOR } from './constants';
 
@@ -34,8 +34,11 @@ export function getPopupRenderFunction(
       address = (selectedFeature.geometry as Point).coordinates;
     }
 
-    const titleHtml = `<div class="${unclusteredLayerId}-popup-title" style="font-weight: ${fontWeight};">${title}</div>`;
-    const addressHtml = `<div class="${unclusteredLayerId}-popup-address">${address}</div>`;
+    const safeTitle = escapeHtml(String(title));
+    const safeAddress = escapeHtml(String(address));
+
+    const titleHtml = `<div class="${unclusteredLayerId}-popup-title" style="font-weight: ${fontWeight};">${safeTitle}</div>`;
+    const addressHtml = `<div class="${unclusteredLayerId}-popup-address">${safeAddress}</div>`;
     const popupHtmlStyle = `background: ${background}; border: ${borderWidth}px solid ${borderColor}; color: ${fontColor}; border-radius: ${radius}px; padding: ${padding}px; word-wrap: break-word; margin: -10px -10px -15px;`;
     let popupHtml = `<div class="${unclusteredLayerId}-popup" style="${popupHtmlStyle}">`;
     if (title) popupHtml += titleHtml;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -121,3 +121,16 @@ export function removeElement(node: HTMLElement): void {
     node.parentNode.removeChild(node);
   }
 }
+
+/**
+ * Escapes HTML special characters to prevent XSS when interpolating
+ * user-controlled strings into HTML markup.
+ */
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}


### PR DESCRIPTION
### Description of changes

Several places in the codebase interpolate user-controlled strings directly into `innerHTML` without sanitization, creating stored/reflected XSS vulnerabilities. An attacker who controls a geofence ID, GeoJSON feature `title`, `address`, or `place_name` property could inject arbitrary HTML/JavaScript that executes in the context of the consuming application.

This PR introduces an `escapeHtml()` utility and applies it to all four vulnerable code paths:

| File | Location | User-controlled value |
|---|---|---|
| `src/utils.ts` | new `escapeHtml()` | — (utility) |
| `src/AmplifyGeofenceControl/ui.ts` | line ~408 | `geofenceId` in list item title |
| `src/AmplifyGeofenceControl/ui.ts` | line ~607 | `geofenceId` in delete confirmation prompt |
| `src/popupRender.ts` | line ~37 | `title` and `address` from GeoJSON feature properties |

The `escapeHtml` function replaces the five HTML-significant characters (`&`, `<`, `>`, `"`, `'`) with their corresponding HTML entities, which is the standard mitigation for injection into HTML element content and attribute values.

### Issue #, if available

### Description of how you validated changes

* Unit tests for `escapeHtml()` with 10 distinct XSS payloads (script tags, event handlers, SVG/iframe injection, attribute breakout, javascript: URIs, etc.)

### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)
