### PR TITLE
ci: bump actions to Node 24-compatible versions (checkout, dependency-review-action)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@e2a5a1afd5d7305b13671410c52a31819ab9fad9 # v4.0.0 https://github.com/actions/checkout/commit/e2a5a1afd5d7305b13671410c52a31819ab9fad9
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/commit/9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@7bbfa034e752445ea40215fff1c3bf9597993d3f # v3.1.3 https://github.com/actions/dependency-review-action/commit/7bbfa034e752445ea40215fff1c3bf9597993d3f
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0 https://github.com/actions/dependency-review-action/commit/a1d282b36b6f3519aa1f3fc636f609c47dddb294
         with:
           config-file: '.github/dependency-review/dependency-review-config.yml'


### PR DESCRIPTION
#### Description of changes

GitHub is [deprecating the Node 20 runtime on Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Actions whose `action.yml` declares a deprecated JS runtime (`node16`/`node20`) are force-run on Node 24 and emit a deprecation warning on every run.

The two actions in `.github/workflows/dependency-review.yml` were pinned to old commit SHAs with deprecated runtimes. This PR bumps both to their **current latest releases**, which declare `runs.using: node24`:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `e2a5a1afd5d7305b13671410c52a31819ab9fad9` — v4.0.0 (`node20`) | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` — **v7.0.0 (`node24`)** |
| `actions/dependency-review-action` | `7bbfa034e752445ea40215fff1c3bf9597993d3f` — v3.1.3 (`node16`) | `a1d282b36b6f3519aa1f3fc636f609c47dddb294` — **v5.0.0 (`node24`)** |

Both actions remain pinned to a full commit SHA with a matching `# vX.Y.Z` comment, per the repo's existing convention. No application code is touched — this is a CI configuration change only.

<details>
<summary>Out of scope — other deprecated-runtime pins (recommend a follow-up PR)</summary>

While auditing the workflows for this change, I found additional actions still pinned to deprecated JS runtimes elsewhere in the repo. They are intentionally **not** included here to keep this PR focused on the two flagged actions, but a follow-up is recommended:

- `actions/checkout@11bd71901…` v4.2.2 (`node20`) — `callable-e2e-test.yml`, `callable-e2e-tests.yml`, `codeql.yml`, `coverage.yml`, `publish.yml`, `actions/setup-samples-staging`
- `actions/setup-node@cdca7365…` v4.3.0 (`node20`) — `actions/node-and-build`, `coverage.yml`, `publish.yml`
- `actions/cache@5a3ec84…` v4.2.3 (`node20`) — `actions/node-and-build`, `actions/setup-samples-staging`
- `actions/upload-artifact@65c4c4a1…` v4.5.0 (`node20`) — `callable-e2e-test.yml`
- `github/codeql-action@d2306014…` v2.12.5 (`node16`) — `codeql.yml`
- `codecov/codecov-action@e1dd05c…` v2.12.2 (`node16`) — `coverage.yml`

</details>

#### Issue #, if available

N/A

#### Description of how you validated changes

- Resolved each new tag to its commit SHA via `gh api repos/<action>/commits/<tag>` and confirmed the pinned SHAs are correct.
- Confirmed both new pins declare a Node 24 runtime by reading their `action.yml` at the pinned SHA (`runs.using: node24`).
- Verified `.github/workflows/dependency-review.yml` still parses as valid YAML.
- The Dependency Review workflow runs on `pull_request`, so this PR itself exercises the updated workflow.

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes — not applicable (CI configuration change only; no source or tests modified)
- [ ] Tests are [changed or added] — not applicable (CI configuration change only)
- [ ] Relevant documentation is changed or added — not applicable

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
