### PR TITLE
ci: bump GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/actions/node-and-build/action.yml
+++ b/.github/actions/node-and-build/action.yml
@@ -10,12 +10,12 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node.js 24
-      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0 https://github.com/actions/setup-node/commit/cdca7365b2dadb8aad0a33bc7601856ffabcc48e
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 https://github.com/actions/setup-node/commit/48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
         node-version: 24
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
-    - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3 https://github.com/actions/cache/commit/5a3ec84eff668545956fd18022155c47e93e2684
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5 https://github.com/actions/cache/commit/27d5ce7f107fe9357f9df03efb73ab90386fccae
       id: cache-build-artifacts
       with:
         path: |

--- a/.github/actions/setup-samples-staging/action.yml
+++ b/.github/actions/setup-samples-staging/action.yml
@@ -12,7 +12,7 @@ runs:
   using: 'composite'
   steps:
     - name: Create cache
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3 https://github.com/actions/cache/commit/5a3ec84eff668545956fd18022155c47e93e2684
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5 https://github.com/actions/cache/commit/27d5ce7f107fe9357f9df03efb73ab90386fccae
       id: cache-samples-staging-build
       with:
         key: aws-amplify-js-samples-staging-build-${{ github.sha }}
@@ -22,7 +22,7 @@ runs:
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
     - name: Checkout staging repo
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/commit/9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         repository: ${{ github.repository_owner }}/amplify-js-samples-staging
         path: amplify-js-samples-staging

--- a/.github/workflows/callable-e2e-test.yml
+++ b/.github/workflows/callable-e2e-test.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/commit/9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           path: maplibre-gl-js-amplify
       - name: Setup node and build the repository
@@ -113,7 +113,7 @@ jobs:
           prod \
           $E2E_AMPLIFY_JS_DIR
       - name: Upload artifact
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.5.0 https://github.com/actions/upload-artifact/commit/65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1 https://github.com/actions/upload-artifact/commit/043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: failure()
         with:
           name: ${{ inputs.test_name }}

--- a/.github/workflows/callable-e2e-tests.yml
+++ b/.github/workflows/callable-e2e-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/commit/9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           path: maplibre-gl-js-amplify
       - name: Read integ config files

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/commit/9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 2
 
       - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0 https://github.com/actions/setup-node/commit/cdca7365b2dadb8aad0a33bc7601856ffabcc48e
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 https://github.com/actions/setup-node/commit/48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [e2e]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/commit/9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Use Node.js 24 x64
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0 https://github.com/actions/setup-node/commit/cdca7365b2dadb8aad0a33bc7601856ffabcc48e
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 https://github.com/actions/setup-node/commit/48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
           architecture: x64


### PR DESCRIPTION
#### Description of changes

GitHub is [deprecating the Node 20 runtime on Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Several actions in our workflows are pinned to SHAs whose releases still declare `runs.using: node20`, so they emit Node 20 deprecation warnings in the **E2E** (`e2e / Get required configs to run e2e tests`, the E2E test-runner jobs), **Publish**, and **coverage** jobs — including the composite actions those jobs call.

This bumps the affected GitHub-owned actions to their latest releases, **all of which run on `node24`**, keeping the repo's existing pinning convention (full commit SHA + `# vX.Y.Z` comment + commit URL):

| Action | Old | New | Runtime |
| --- | --- | --- | --- |
| `actions/checkout` | `11bd719…` (v4.2.2) | `9c091bb…` (v7.0.0) | node24 |
| `actions/setup-node` | `cdca736…` (v4.3.0) | `48b55a0…` (v6.4.0) | node24 |
| `actions/cache` | `5a3ec84…` (v4.2.3) | `27d5ce7…` (v5.0.5) | node24 |
| `actions/upload-artifact` | `65c4c4a…` (v4.5.0) | `043fb46…` (v7.0.1) | node24 |

Files touched:
- `.github/workflows/callable-e2e-test.yml` — checkout, upload-artifact
- `.github/workflows/callable-e2e-tests.yml` — checkout
- `.github/workflows/coverage.yml` — checkout, setup-node
- `.github/workflows/publish.yml` — checkout, setup-node
- `.github/actions/node-and-build/action.yml` — setup-node, cache
- `.github/actions/setup-samples-staging/action.yml` — cache, checkout

This **completes** the Node 24 action migration started in #281, which only bumped `actions/checkout` and `actions/dependency-review-action` in `dependency-review.yml` (already on `node24`, untouched here).

`codecov/codecov-action` (v2.12.2) is a third-party action and is intentionally left out of scope — bumping it to a current major involves token/behavior changes and should be a separate PR.

#### Issue #, if available

N/A — follow-up to #281 for the Node 20 runner deprecation.

#### Description of how you validated changes

- Resolved every new pin to the **latest release** via the GitHub API (`gh api repos/actions/<name>/releases/latest` + `…/commits/<tag>`) so each SHA is real and current — no invented SHAs. The `actions/checkout@9c091bb…` SHA matches the one the maintainers already committed for v7.0.0 in #281.
- Confirmed each new release declares `runs.using: node24` by reading its `action.yml` at the pinned tag.
- Verified `actions/upload-artifact@v7.0.1` still accepts the inputs used here (`name`, `path`, `if-no-files-found`, `retention-days`).
- Validated all workflow/composite YAML parses cleanly; `git grep` confirms **no** Node-20 SHAs remain.
- Diff is a pure line-for-line SHA/version swap (11 lines) — no workflow logic, steps, inputs, or other config changed.

#### Checklist

- [x] PR description included
- [x] CI-config-only change — workflow YAML validated and pinned SHAs verified against the GitHub API
- [ ] ~`yarn test` passes~ — N/A, no source/test changes
- [ ] ~Tests are changed or added~ — N/A, CI configuration only
- [ ] ~Relevant documentation is changed or added~ — N/A
