### PR TITLE
fix(deps): bump form-data to 3.0.5 to fix CRLF injection (GHSA-hmw2-7cc7-3qxx)

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
   "resolutions": {
     "**/fast-xml-parser": "4.4.1",
     "cross-spawn": "7.0.5",
+    "form-data": "^3.0.5",
     "json5": "^2.2.2",
     "optionator": "^0.9.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5519,15 +5519,15 @@ for-each@^0.3.3:
   dependencies:
     is-callable "^1.1.3"
 
-form-data@^3.0.0:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.4.tgz#938273171d3f999286a4557528ce022dc2c98df1"
-  integrity sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==
+form-data@^3.0.0, form-data@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.5.tgz#2ea3ec24f0dcb7e0262a11efb732031240ea8e9f"
+  integrity sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
-    hasown "^2.0.2"
+    hasown "^2.0.4"
     mime-types "^2.1.35"
 
 from2@^2.3.0:
@@ -5919,6 +5919,13 @@ hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  dependencies:
+    function-bind "^1.1.2"
+
+hasown@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
   dependencies:
     function-bind "^1.1.2"
 


### PR DESCRIPTION
#### Description of changes

Fixes the failing **dependency-review** check (`Dependency review detected vulnerable packages.`) for **form-data**.

**Advisory:** [GHSA-hmw2-7cc7-3qxx](https://github.com/advisories/GHSA-hmw2-7cc7-3qxx) / CVE-2026-12143 — *CRLF injection in form-data via unescaped multipart field names and filenames* (**HIGH**, CVSS 8.7, CWE-93).

`form-data` builds the multipart `Content-Disposition` header by concatenating the field `name` and `filename` directly, with no escaping of `\r`, `\n`, or `"`. An app that uses untrusted input as a field name/filename can therefore terminate the header line and inject headers or smuggle additional multipart parts.

- **Affected:** `< 2.5.6`, `>= 3.0.0 < 3.0.5`, `>= 4.0.0 < 4.0.6`
- **Patched:** `2.5.6`, `3.0.5`, `4.0.6`

**Direct or transitive?** Transitive, **dev-only**. `form-data@3.0.4` is pulled in via the test toolchain:

```
jest -> @jest/core -> jest-config -> jest-environment-jsdom -> jsdom -> form-data@^3.0.0
```

It is not a runtime/production dependency of the published package (`yarn why form-data` confirms the jsdom chain).

**What changed (minimal, scoped):**

- `package.json` — added a Yarn (classic v1) `resolutions` entry `"form-data": "^3.0.5"`, consistent with the existing security pins already in that block (`**/fast-xml-parser`, `cross-spawn`, `json5`, `optionator`). `3.0.5` is the patched release on the **3.x** line the repo already resolves to (`^3.0.0`), so this is **not** a breaking major bump.
- `yarn.lock` — `form-data` `3.0.4 -> 3.0.5`; its `hasown` requirement moves `^2.0.2 -> ^2.0.4` (resolves to `hasown@2.0.4`). No other dependencies were touched.

#### Issue #, if available

N/A — addresses the dependency-review / Dependabot alert for GHSA-hmw2-7cc7-3qxx.

#### Description of how you validated changes

- `yarn install --frozen-lockfile` exits **0** (lockfile is consistent with `package.json`).
- `yarn why form-data` reports `Found "form-data@3.0.5"`; the vulnerable `3.0.4` is no longer present in `yarn.lock`.
- `yarn test` -> **8 suites / 111 tests pass** on Node 24 (matching CI). `form-data` is exercised transitively by the jsdom test environment, so a green suite confirms the bump does not break tooling.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are changed or added <!-- N/A: dependency lockfile/security fix, no source change -->
- [ ] Relevant documentation is changed or added <!-- N/A -->

<!-- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. -->
