### PR TITLE
chore: bump version to 4.0.3 to match latest npm release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maplibre-gl-js-amplify",
-  "version": "4.0.0",
+  "version": "4.0.3",
   "description": "MapLibre Plugin to Support Amplify Geo Integration",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",


### PR DESCRIPTION
## What

Bump the `version` field in `package.json` from **4.0.0** → **4.0.3** to match the latest published release on npm.

## Why

The committed `package.json` version had drifted behind the npm registry:

| Source | Version |
|---|---|
| `package.json` (repo) | `4.0.0` |
| npm `dist-tag: latest` | `4.0.3` |

Verified against the registry:

```
$ npm view maplibre-gl-js-amplify version
4.0.3

$ npm view maplibre-gl-js-amplify dist-tags
{ ..., latest: '4.0.3', ... }
```

This repo uses **semantic-release**, which publishes new versions to npm without committing the bumped version back to `package.json`. As a result the committed version (`4.0.0`) lagged behind the current npm latest (`4.0.3`). This change re-aligns the repo with the published release.

## Scope

Minimal, focused change — a single line in `package.json`. No other files declare the package's own version (yarn.lock has no root version field, there is no `package-lock.json`, no source constant, and the README badges are dynamic). No functional/code changes.